### PR TITLE
[otbn,util] Modify otbn_sim_test wrapper to show where the dmem mismatch is for debugging.

### DIFF
--- a/hw/ip/otbn/util/otbn_sim_test.py
+++ b/hw/ip/otbn/util/otbn_sim_test.py
@@ -158,12 +158,15 @@ def main() -> int:
             for label, value in expected_dmem.items():
                 try:
                     offset = symbol_addr_map[label]
-                    if actual_dmem[offset:offset + len(value)] != value:
-                        result.err(
-                            f"Mismatch for dmem {label}:\n"
-                            f"  Expected: {value.hex()}\n"
-                            f"  Actual:   {actual_dmem[offset:offset+len(value)].hex()}"
-                        )
+                    for i in range(0, len(value), 4):
+                        actual = actual_dmem[offset + i: offset + i + 4]
+                        expected = value[i: i + 4]
+                        if actual != expected:
+                            result.err(
+                                f"Mismatch for dmem {label} at word {i // 4}:\n"
+                                f"  Expected: {expected.hex()}\n"
+                                f"  Actual:   {actual.hex()}"
+                            )
                 except KeyError:
                     result.err(f'No label "{label}" found in elf-file.')
 


### PR DESCRIPTION
Previously, dmem mismatches (.dexp) were shown as a single block, which is difficult to pinpoint the exact location of the mismatch. This commit performs a word-by-word (4-byte) check. If a mismatch is detected, the error message now indicates the specific word index, along with the expected and actual word values in hex.

This helps debugging process when .dexp files are large, e.g., in ML-KEM and ML-DSA tests. By pointing out the exact mismatch words, we can identify quickly where the errors might come from. 