### PR TITLE
[mldsa] Compute y on the fly during signing to save memory.

### DIFF
--- a/sw/otbn/crypto/mldsa/poly_dilithium.s
+++ b/sw/otbn/crypto/mldsa/poly_dilithium.s
@@ -698,7 +698,7 @@ _loop_inner_skip_load_poly_challenge:
  * @param[in]  a2: nonce
  * @param[out] a1: dmem pointer to polynomial
  *
- * clobbered registers: a0-a5, t0-t5, w8, w16
+ * clobbered registers: a0-a5, t0-t6, w8, w16
  */
 .global poly_uniform
 poly_uniform:
@@ -2054,8 +2054,6 @@ poly_uniform_gamma1_dilithium:
     /* copy output pointer */
     addi t1, a0, 0
 
-    push a1
-
     /* Initialize a SHAKE256 operation. */
     addi a0, a1, 0    /* save a0 <= seed address */
 
@@ -2152,8 +2150,6 @@ poly_uniform_gamma1_dilithium:
 
     /* Finish the SHAKE-256 operation. */
 
-    pop a1
-
     ret
 
 _inner_poly_uniform_gamma1_dilithium:
@@ -2174,8 +2170,6 @@ _inner_poly_uniform_gamma1_dilithium:
 #elif GAMMA1 == (1 << 19)
     /* copy output pointer */
     addi t1, a0, 0
-
-    push a1
 
     /* Initialize a SHAKE256 operation. */
     addi a0, a1, 0    /* a0 <= seed address */
@@ -2245,8 +2239,6 @@ _inner_poly_uniform_gamma1_dilithium:
         nop /* Must not end on branch */
 
     /* Finish the SHAKE-256 operation. */
-
-    pop a1
 
     ret
 

--- a/sw/otbn/crypto/mldsa/sign_dilithium.s
+++ b/sw/otbn/crypto/mldsa/sign_dilithium.s
@@ -223,22 +223,21 @@ sign_dilithium:
     #define STACK_RND -160 /* Prev - 32 */
     #define STACK_KEY -192 /* Prev - 32 */
     #define STACK_RHOPRIME -192 /* Prev */
-
 #if DILITHIUM_MODE == 2
     #define STACK_T0  -4288 /* Prev - K*1024 */
     #define STACK_S1  -8384 /* Prev - L*1024 */
     #define STACK_S2  -12480 /* Prev - K*1024 */
     #define STACK_MAT  -13504 /* Prev - 1024 */
         #define STACK_CP  -13504 /* Prev */
-    #define STACK_Y  -17600 /* Prev - K*1024 */
-        #define STACK_H  -17600 /* Prev */
-    #define STACK_Z  -21696 /* Prev - L*1024 */
-    #define STACK_W1  -25792 /* Prev - K*1024 */
-    #define STACK_W0  -29888 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -29888 /* Prev */
-    #define STACK_CTX  -29892 /* Prev - 4 */
-    #define INIT_SP -29920
-    #define STACK_SIZE -30048
+    #define STACK_Y  -14528 /* Prev - 1024 */
+    #define STACK_Z  -18624 /* Prev - L*1024 */
+    #define STACK_W1  -22720 /* Prev - K*1024 */
+        #define STACK_H  -22720 /* Prev */
+    #define STACK_W0  -26816 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -26816 /* Prev */
+    #define STACK_CTX  -26820 /* Prev - 4 */
+    #define INIT_SP -26848
+    #define STACK_SIZE -26976
 
 #elif DILITHIUM_MODE == 3
     #define STACK_T0  -6336 /* Prev - K*1024 */
@@ -246,15 +245,15 @@ sign_dilithium:
     #define STACK_S2  -17600 /* Prev - K*1024 */
     #define STACK_MAT  -18624 /* Prev - 1024 */
         #define STACK_CP  -18624 /* Prev */
-    #define STACK_Y  -24768 /* Prev - K*1024 */
-        #define STACK_H  -24768 /* Prev */
-    #define STACK_Z  -29888 /* Prev - L*1024 */
-    #define STACK_W1  -36032 /* Prev - K*1024 */
-    #define STACK_W0  -42176 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -42176 /* Prev */
-    #define STACK_CTX  -42180 /* Prev - 4 */
-    #define INIT_SP -42208
-    #define STACK_SIZE -42336
+    #define STACK_Y  -19648 /* Prev - 1024 */
+    #define STACK_Z  -24768 /* Prev - L*1024 */
+    #define STACK_W1  -30912 /* Prev - K*1024 */
+        #define STACK_H  -30912 /* Prev */
+    #define STACK_W0  -37056 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -37056 /* Prev */
+    #define STACK_CTX  -37060 /* Prev - 4 */
+    #define INIT_SP -37088
+    #define STACK_SIZE -37216
 
 #elif DILITHIUM_MODE == 5
     #define STACK_T0  -8384 /* Prev - K*1024 */
@@ -262,15 +261,15 @@ sign_dilithium:
     #define STACK_S2  -23744 /* Prev - K*1024 */
     #define STACK_MAT  -24768 /* Prev - 1024 */
         #define STACK_CP  -24768 /* Prev */
-    #define STACK_Y  -32960 /* Prev - K*1024 */
-        #define STACK_H  -32960 /* Prev */
-    #define STACK_Z  -40128 /* Prev - L*1024 */
-    #define STACK_W1  -48320 /* Prev - K*1024 */
-    #define STACK_W0  -56512 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -56512 /* Prev */
-    #define STACK_CTX  -56516 /* Prev - 4 */
-    #define INIT_SP -56544
-    #define STACK_SIZE -56672
+    #define STACK_Y  -25792 /* Prev - 1024 */
+    #define STACK_Z  -32960 /* Prev - L*1024 */
+    #define STACK_W1  -41152 /* Prev - K*1024 */
+        #define STACK_H  -41152 /* Prev */
+    #define STACK_W0  -49344 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -49344 /* Prev */
+    #define STACK_CTX  -49348 /* Prev - 4 */
+    #define INIT_SP -49376
+    #define STACK_SIZE -49504
 #endif
     /* Initialize the frame pointer */
     addi fp, sp, 0
@@ -613,103 +612,89 @@ sign_dilithium:
     li s11, 0 /* nonce */
 
 _rej_sign_dilithium:
-    /* Uniform GAMMA1 */
-    li  a1, STACK_RHOPRIME
-    add a1, fp, a1
-
-    li  a0, STACK_Y
-    add a0, fp, a0
-
-    addi a2, s11, 0 /* Compute nonce */
-    la   a3, gamma1_vec_const
-
-    LOOPI L, 3
-        jal  x1, poly_uniform_gamma1_dilithium
-        addi a0, a0, 1024
-        addi a2, a2, 1 /* a2 should be preserved after execution */
-
-    addi s11, s11, L
-
-    /* NTT(Y) -> Z */
-    li  a0, STACK_Y
-    add a0, fp, a0 /* in */
-    li  a2, STACK_Z
-    add a2, fp, a2 /* out */
-    la  a1, twiddles_fwd
-
-  .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-     push \reg
-  .endr
-
-    LOOPI L, 2
-        jal x1, ntt_dilithium
-        addi a1, a1, -1024
-
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-      pop \reg
-    .endr
-
     /* Matrix-vector multiplication */
 
-    /* Load source pointers */
-    li  a0, STACK_Z
-    add a0, fp, a0
-    li  a1, STACK_MAT
-    add a1, fp, a1
+    /* Save some stack offsets. */
+    li s0, STACK_Y
+    add s0, fp, s0
+    li s1, STACK_W1
+    add s1, fp, s1
+    li s2, STACK_MAT
+    add s2, fp, s2
+    li s3, STACK_RHOPRIME
+    add s3, fp, s3
+    li s5, STACK_RHO
+    add s5, fp, s5
 
-    /* Load destination pointer */
-    li  a2, STACK_W1
-    add a2, fp, a2
+    /* Initialize destination to 0. */
+    li t0, 31
+    addi a3, s1, 0
+    LOOPI K, 3
+        LOOPI 32, 1
+          bn.sid t0, 0(a3++)
+        nop
 
-    /* Load offset for resetting pointer */
-    li s0, POLYVECL_BYTES
+    /* Load the constant for resetting the w1 pointer. */
+    li s6, POLYVECK_BYTES
 
     /* Initialize the nonce for matrix expansion. This value should be
          byte(i) || byte(j)
        for entry A[i][j]. */
-    li a3, 0
+    li s4, 0
 
-    /* Compute A * y, computing the values for A on the fly. */
-    .rept K
-        push a0
-        push a2
-        push a3
-        li  a0, STACK_RHO
-        add a0, fp, a0
-        addi a2, a3, 0
-        jal  x1, poly_uniform
-        addi a1, a1, -1024
-        pop a3
-        pop a2
-        pop a0
-        addi a3, a3, 1
-        jal  x1, poly_pointwise_dilithium
-        addi a1, a1, -1024
-        addi a2, a2, -1024
-        .rept L-1
-            push a0
-            push a2
-            push a3
-            li  a0, STACK_RHO
-            add a0, fp, a0
-            addi a2, a3, 0
+    /* Compute A * y, computing the values for A and y on the fly.
+
+       We compute column-wise so that we genearate elements of y only once; in
+       pseudocode, this computation does:
+
+         for j in 0..l-1:
+           yj = ntt(y[j])
+           for i in 0..k-1:
+             w1[i] += A[i][j] * yj
+    */
+    .rept L
+        /* Compute y[j], storing temporarily in the matrix poly buffer. */
+        li   a0, STACK_MAT
+        add  a0, fp, a0
+        li   a1, STACK_RHOPRIME
+        add  a1, fp, a1
+        addi a2, s11, 0 /* y sampling nonce */
+        la   a3, gamma1_vec_const
+        jal  x1, poly_uniform_gamma1_dilithium
+        addi s11, a2, 1 /* a2 should be preserved after execution */
+        /* Compute ntt(y[j]). */
+        li   a0, STACK_MAT
+        add  a0, fp, a0
+        la  a1, twiddles_fwd
+        li   a2, STACK_Y
+        add  a2, fp, a2
+        jal x1, ntt_dilithium
+        .rept K
+            /* Compute A[i][j]. */
+            li   a0, STACK_RHO
+            add  a0, fp, a0
+            li   a1, STACK_MAT
+            add  a1, fp, a1
+            addi a2, s4, 0 /* matrix nonce */
             jal  x1, poly_uniform
-            pop a3
-            pop a2
-            pop a0
-            addi a1, a1, -1024
-            addi a3, a3, 1
+            li   a0, STACK_Y
+            add  a0, fp, a0
+            li   a1, STACK_MAT
+            add  a1, fp, a1
+            addi a2, s1, 0 /* *W1[i] */
+            /* Add A[i][j] * y[j] to w1[i]. */
             jal  x1, poly_pointwise_acc_dilithium
-            addi a1, a1, -1024
-            addi a2, a2, -1024
+            /* Increment the w1 pointer. */
+            addi s1, s1, 1024
+            /* Increment the row index by 1. */
+            addi s4, s4, 256
         .endr
-        /* Reset input vector pointer */
-        sub  a0, a0, s0
-        addi a2, a2, 1024
-        /* Increment the row index in the nonce by one. */
-        addi a3, a3, 256
-        /* Reset the column index in the nonce to zero. */
-        addi a3, a3, -L
+        /* Reset w1 pointer. */
+        sub  s1, s1, s6
+        /* Increment the column index in the nonce by one. */
+        addi s4, s4, 1
+        /* Reset the row index in the nonce to zero. */
+        andi s4, s4, 255
     .endr
 
     /* Inverse NTT on w1 */
@@ -916,17 +901,33 @@ _rej_sign_dilithium:
         pop \reg
     .endr
 
-    /* z = z + y */
-    li  a0, STACK_Z
-    add a0, fp, a0
-    li  a1, STACK_Y
-    add a1, fp, a1
-    li  a2, STACK_Z
-    add a2, fp, a2
+    /* Add y to z, computing values of y on the fly. */
+    addi s11, s11, -L /* reset y nonce */
+    la   a3, gamma1_vec_const
 
-    LOOPI L, 2
+    /* Initialize pointers to y and z. */
+    li  a0, STACK_Y
+    add a0, fp, a0
+    li  a1, STACK_Z
+    add a1, fp, a1
+
+    /* Store some stack offsets to avoid using li within a loop. */
+    li s0, STACK_RHOPRIME
+
+    LOOPI L, 9
+        /* Save the z pointer. */
+        addi s1, a1, 0
+        /* Sample the next value of y. */
+        add a1, fp, s0
+        addi a2, s11, 0
+        jal  x1, poly_uniform_gamma1_dilithium
+        addi s11, a2, 1 /* a2 should be preserved after execution */
+        /* z[i] += y[i] */
+        addi a1, s1, 0
+        addi a2, s1, 0
         jal x1, poly_add_dilithium
-        nop
+        /* Reset the pointer to the buffer for y[i]. */
+        addi a0, a0, -1024
 
     /* reduce32(z) to move to mod^{+-} for bound check */
     li  a0, STACK_Z

--- a/sw/otbn/crypto/mldsa/sign_dilithium.s
+++ b/sw/otbn/crypto/mldsa/sign_dilithium.s
@@ -222,13 +222,12 @@ sign_dilithium:
     #define STACK_RHO -128 /* Prev - 32 */
     #define STACK_RND -160 /* Prev - 32 */
     #define STACK_KEY -192 /* Prev - 32 */
-    #define STACK_RHOPRIME -192 /* Prev */
+        #define STACK_RHOPRIME -192 /* Prev */
 #if DILITHIUM_MODE == 2
     #define STACK_T0  -4288 /* Prev - K*1024 */
     #define STACK_S1  -8384 /* Prev - L*1024 */
     #define STACK_S2  -12480 /* Prev - K*1024 */
-    #define STACK_MAT  -13504 /* Prev - 1024 */
-        #define STACK_CP  -13504 /* Prev */
+    #define STACK_CP  -13504 /* Prev - 1024 */
     #define STACK_Y  -14528 /* Prev - 1024 */
     #define STACK_Z  -18624 /* Prev - L*1024 */
     #define STACK_W1  -22720 /* Prev - K*1024 */
@@ -243,8 +242,7 @@ sign_dilithium:
     #define STACK_T0  -6336 /* Prev - K*1024 */
     #define STACK_S1  -11456 /* Prev - L*1024 */
     #define STACK_S2  -17600 /* Prev - K*1024 */
-    #define STACK_MAT  -18624 /* Prev - 1024 */
-        #define STACK_CP  -18624 /* Prev */
+    #define STACK_CP  -18624 /* Prev - 1024 */
     #define STACK_Y  -19648 /* Prev - 1024 */
     #define STACK_Z  -24768 /* Prev - L*1024 */
     #define STACK_W1  -30912 /* Prev - K*1024 */
@@ -259,8 +257,7 @@ sign_dilithium:
     #define STACK_T0  -8384 /* Prev - K*1024 */
     #define STACK_S1  -15552 /* Prev - L*1024 */
     #define STACK_S2  -23744 /* Prev - K*1024 */
-    #define STACK_MAT  -24768 /* Prev - 1024 */
-        #define STACK_CP  -24768 /* Prev */
+    #define STACK_CP  -24768 /* Prev - 1024 */
     #define STACK_Y  -25792 /* Prev - 1024 */
     #define STACK_Z  -32960 /* Prev - L*1024 */
     #define STACK_W1  -41152 /* Prev - K*1024 */
@@ -390,7 +387,7 @@ sign_dilithium:
     li t2, STACK_CTXLEN
     add a0, fp, t2
     lw t2, 0(a0) /* t2 <= ctxlen */
-    li t3, STACK_CP /* Re-use CP buffer for absorbing ctxlen and ctx */
+    li t3, STACK_Z /* Re-use Z buffer for absorbing ctxlen and ctx */
     add t3, fp, t3
 
     /* Note: Add support for non-4B multiple ctxlen */
@@ -490,7 +487,7 @@ sign_dilithium:
     /* a1 still contains length but includes TRBYTES */
     addi a1, a1, -TRBYTES
 
-    li t3, STACK_CP /* Re-use CP buffer for absorbing ctxlen and ctx */
+    li t3, STACK_Z /* Re-use Z buffer for absorbing ctxlen and ctx */
     add a0, fp, t3
 
     jal x1, keccak_send_message
@@ -614,24 +611,16 @@ sign_dilithium:
 _rej_sign_dilithium:
     /* Matrix-vector multiplication */
 
-    /* Save some stack offsets. */
-    li s0, STACK_Y
-    add s0, fp, s0
+    /* Get destination pointer. */
     li s1, STACK_W1
     add s1, fp, s1
-    li s2, STACK_MAT
-    add s2, fp, s2
-    li s3, STACK_RHOPRIME
-    add s3, fp, s3
-    li s5, STACK_RHO
-    add s5, fp, s5
 
     /* Initialize destination to 0. */
     li t0, 31
-    addi a3, s1, 0
+    addi t1, s1, 0
     LOOPI K, 3
         LOOPI 32, 1
-          bn.sid t0, 0(a3++)
+          bn.sid t0, 0(t1++)
         nop
 
     /* Load the constant for resetting the w1 pointer. */
@@ -654,7 +643,7 @@ _rej_sign_dilithium:
     */
     .rept L
         /* Compute y[j], storing temporarily in the matrix poly buffer. */
-        li   a0, STACK_MAT
+        li   a0, STACK_Y
         add  a0, fp, a0
         li   a1, STACK_RHOPRIME
         add  a1, fp, a1
@@ -663,7 +652,7 @@ _rej_sign_dilithium:
         jal  x1, poly_uniform_gamma1_dilithium
         addi s11, a2, 1 /* a2 should be preserved after execution */
         /* Compute ntt(y[j]). */
-        li   a0, STACK_MAT
+        li   a0, STACK_Y
         add  a0, fp, a0
         la  a1, twiddles_fwd
         li   a2, STACK_Y
@@ -673,13 +662,13 @@ _rej_sign_dilithium:
             /* Compute A[i][j]. */
             li   a0, STACK_RHO
             add  a0, fp, a0
-            li   a1, STACK_MAT
+            li   a1, STACK_Z
             add  a1, fp, a1
             addi a2, s4, 0 /* matrix nonce */
             jal  x1, poly_uniform
             li   a0, STACK_Y
             add  a0, fp, a0
-            li   a1, STACK_MAT
+            li   a1, STACK_Z
             add  a1, fp, a1
             addi a2, s1, 0 /* *W1[i] */
             /* Add A[i][j] * y[j] to w1[i]. */
@@ -777,69 +766,44 @@ _rej_sign_dilithium:
 
     /* Setup WDR */
     li t1, 8
+    /* Restore a0*/
+    addi    a0, s0, 0
 
+    /* Read first 32 bytes of digest. */
+    bn.wsrr w8, 0xA
+
+    /* Get always-aligned temporary buffer. */
+    li   t0, STACK_CP
+    add  t0, fp, t0
 #if CTILDEBYTES == 32
-    bn.wsrr w8, 0xA   /* KECCAK_DIGEST */
-    addi    a0, s0, 0 /* restore a0 */
-    /* Get temp buffer */
-    li   t0, STACK_CP
-    add  t0, fp, t0
-    bn.sid  t1, 0(t0) /* Store CTILDE into temp buffer */
-    LOOPI 8, 4
-        lw t2, 0(t0)
-        sw t2, 0(a0)
-        addi t0, t0, 4
-        addi a0, a0, 4
-
-    addi a0, a0, -CTILDEBYTES
+    /* Store first 32 bytes into temp buffer and signature. */
+    bn.sid  t1, 0(t0)
+    bn.sid  t1, 0(a0)
 #elif CTILDEBYTES == 48
-    bn.wsrr w8, 0xA   /* KECCAK_DIGEST */
-    addi    a0, s0, 0 /* restore a0 */
-
-    /* Get temp buffer */
-    li   t0, STACK_CP
-    add  t0, fp, t0
-    bn.sid  t1, 0(t0) /* Store CTILDE into temp buffer */
+    /* Store first 32 bytes into temp buffer and (unaligned) signature. */
+    bn.sid  t1, 0(t0)
     LOOPI 8, 4
         lw t2, 0(t0)
         sw t2, 0(a0)
         addi t0, t0, 4
         addi a0, a0, 4
 
-    bn.wsrr w8, 0xA   /* KECCAK_DIGEST */
-
-    bn.sid  t1, 0(t0) /* Store CTILDE into temp buffer */
+    /* Read 32 more bytes and store 16 of them. */
+    bn.wsrr w8, 0xA
+    bn.sid  t1, 0(t0)
     LOOPI 4, 4
         lw t2, 0(t0)
         sw t2, 0(a0)
         addi t0, t0, 4
         addi a0, a0, 4
-
-    addi a0, a0, -CTILDEBYTES
 #elif CTILDEBYTES == 64
-    bn.wsrr w8, 0xA   /* KECCAK_DIGEST */
-    addi    a0, s0, 0 /* restore a0 */
-
-    /* Get temp buffer */
-    li   t0, STACK_CP
-    add  t0, fp, t0
-    bn.sid  t1, 0(t0) /* Store CTILDE into temp buffer */
-    LOOPI 8, 4
-        lw t2, 0(t0)
-        sw t2, 0(a0)
-        addi t0, t0, 4
-        addi a0, a0, 4
-
-    bn.wsrr w8, 0xA   /* KECCAK_DIGEST */
-
-    bn.sid  t1, 0(t0) /* Store CTILDE into temp buffer */
-    LOOPI 8, 4
-        lw t2, 0(t0)
-        sw t2, 0(a0)
-        addi t0, t0, 4
-        addi a0, a0, 4
-
-    addi a0, a0, -CTILDEBYTES
+    /* Store first 32 bytes into temp buffer and signature. */
+    bn.sid  t1, 0(t0)
+    bn.sid  t1, 0(a0)
+    /* Store 32 more bytes (both places). */
+    bn.wsrr w8, 0xA
+    bn.sid  t1, 32(t0)
+    bn.sid  t1, 32(a0)
 #endif
 
     /* Finish the SHAKE-256 operation. */

--- a/sw/otbn/crypto/tests/mldsa/dilithium_sign_test.s
+++ b/sw/otbn/crypto/tests/mldsa/dilithium_sign_test.s
@@ -34,7 +34,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1312
 #define CRYPTO_SECRETKEYBYTES 2560
 #define CRYPTO_BYTES 2420
-#define STACK_SIZE 30048 /* minimum 31KB */
+#define STACK_SIZE 26976 /* minimum 27KB */
 
 #elif DILITHIUM_MODE == 3
 #define K 6
@@ -50,7 +50,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1952
 #define CRYPTO_SECRETKEYBYTES 4032
 #define CRYPTO_BYTES 3309
-#define STACK_SIZE 42336 /* minimum 43KB */
+#define STACK_SIZE 37216 /* minimum 38KB */
 
 #elif DILITHIUM_MODE == 5
 #define K 8
@@ -66,7 +66,7 @@
 #define CRYPTO_PUBLICKEYBYTES 2592
 #define CRYPTO_SECRETKEYBYTES 4896
 #define CRYPTO_BYTES 4627
-#define STACK_SIZE 56672 /* minimum 57KB */
+#define STACK_SIZE 49504 /* minimum 50KB */
 
 #endif
 


### PR DESCRIPTION
On top of #11 

Reduces stack size by {4,5,7}kB for Dilithium{2,3,5} at a performance cost of 2-5% per rejection sampling loop.

```
Stats for rejection loops in dilithium2_sign_test:
160824	-> 167030	(+6206 cycles, +3.86%)
158625	-> 164831	(+6206 cycles, +3.91%)
164084	-> 170290	(+6206 cycles, +3.78%)
137149	-> 143355	(+6206 cycles, +4.53%)
160027	-> 166233	(+6206 cycles, +3.88%)

Stats for rejection loops in dilithium3_sign_test:
257386	-> 265293	(+7907 cycles, +3.07%)

Stats for rejection loops in dilithium5_sign_test:
379003	-> 389931	(+10928 cycles, +2.88%)
430927	-> 441855	(+10928 cycles, +2.54%)
429061	-> 439989	(+10928 cycles, +2.55%)
381689	-> 392617	(+10928 cycles, +2.86%)
374695	-> 385623	(+10928 cycles, +2.92%)
```