### PR TITLE
[mldsa] Compress w1 and rearrange polynomial buffers for ML-DSA.

### DIFF
--- a/sw/otbn/crypto/mldsa/poly_dilithium.s
+++ b/sw/otbn/crypto/mldsa/poly_dilithium.s
@@ -1565,6 +1565,49 @@ _inner_polyt0_pack_dilithium:
     ret
 
 /**
+ * poly_nonzero_encode_dilithium
+ *
+ * Compactly encode the coefficients of the polynomial which are nonzero mod q.
+ *
+ * The bit at index (255-i) in the output 256-bit value is 1 if and only if the
+ * coefficient i of the input is nonzero mod q. The bits are in "reverse order"
+ * for more convenient iteration.
+ *
+ * Expects input in the range [0, q).
+ *
+ * Flags: -
+ *
+ * @param[in]  a0: pointer to input polynomial
+ * @param[out] w0: Representative of nonzero coefficients.
+ *
+ * clobbered registers: a0, t0, w0-w4
+ */
+.global poly_nonzero_encode_dilithium
+poly_nonzero_encode_dilithium:
+    /* Initialize accumulator to zero. */
+    bn.mov w0, w31
+
+    /* Create a 32-bit mask. */
+    bn.not w2, w31
+    bn.rshi w2, w31, w2 >> 224
+
+    /* Set up WDR pointer. */
+    li  t0, 1
+
+    /* Loop through the coefficients. */
+    loopi 32, 8
+        bn.lid t0, 0(a0++)
+        loopi 8, 5
+          bn.add   w0, w0, w0
+          bn.addi  w3, w0, 1
+          bn.and   w4, w1, w2
+          bn.sel   w0, w0, w3, FG0.Z
+          bn.rshi  w1, w31, w1 >> 32
+        nop
+
+    ret
+
+/**
  * polyw1_pack_dilithium
  *
  * Bit-pack polynomial w1 with coefficients fitting in 6 bits. Input
@@ -2270,7 +2313,7 @@ _inner_poly_uniform_gamma1_dilithium:
  * Flags: -
  *
  * @param[out] a0: a0 pointer to output polynomial with coefficients c0
- * @param[out] a1: a1: pointer to output polynomial with coefficients c1
+ * @param[out] a1: a1 pointer to output polynomial with coefficients c1
  * @param[in]  a2: *a: pointer to input polynomial
  *
  * clobbered registers: w0-w11, a0-a2, t0-t4
@@ -2334,11 +2377,14 @@ poly_decompose_dilithium:
  *  the high bits.
  *  The function accepts inputs mod^+ q.
  *
+ * Expects the high part of the polynomial to be represented with 256 bits, in
+ * the format produced by poly_nonzero_encode_dilithium.
+ *
  * Returns: Number of one bits
  *
  * @param[out] a0: pointer to output hint polynomial
  * @param[in]  a1: a0 pointer to low part of input polynomial
- * @param[in]  a2: a1: pointer to high part of input polynomial
+ * @param[in]  w0: 256b representative of nonzero values in high part of polynomial
  *
  * clobbered registers: t0-t2, t4-t6, a0-a2, a4-a7
  */
@@ -2357,7 +2403,6 @@ poly_make_hint_dilithium:
     /* Loop over every coefficient pair of the input */
     LOOPI 256, 21
         lw t0, 0(a1)
-        lw t1, 0(a2)
 
         sub t5, t6, t0 /* Check t0 < (gamma2 + 1) <=> 0 < (gamma2 + 1) - t0 */
         srli t3, t5, 31
@@ -2369,12 +2414,16 @@ poly_make_hint_dilithium:
 
         bne t0, a7, _return1
         li t3, 0
+
+        /* Branch to the end if the high part coefficient is 0. */
+        bn.add  w0, w0, w0
+        csrrs   t1, FG0, zero
+        andi    t1, t1, 1
         beq t1, zero, _loop_end_poly_make_hint_dilithium
-        beq t1, a6, _loop_end_poly_make_hint_dilithium
-        beq zero, zero, _return1
+        jal x0, _return1
 _return0:
         li t3, 0
-        beq zero, zero, _loop_end_poly_make_hint_dilithium
+        jal x0, _loop_end_poly_make_hint_dilithium
 _return1:
         li t3, 1
         /* Fall through to loop end */
@@ -2382,7 +2431,6 @@ _loop_end_poly_make_hint_dilithium:
         sw   t3, 0(a0) /* Write to output polynomial */
         add  t2, t2, t3
         addi a1, a1, 4
-        addi a2, a2, 4
         addi a0, a0, 4
 
     addi a0, t2, 0 /* move result to return value */

--- a/sw/otbn/crypto/mldsa/poly_dilithium.s
+++ b/sw/otbn/crypto/mldsa/poly_dilithium.s
@@ -2083,14 +2083,18 @@ _inner_polyt0_unpack_dilithium:
  *  Sample polynomial with uniformly random coefficients in [-(GAMMA1 - 1),
  *  GAMMA1] by unpacking output stream of SHAKE256(seed|nonce).
  *
+ * Accumulates the result onto the existing value in the output polynomial
+ * register; the caller should zero this value if only the sampling output is
+ * desired.
+ *
  * Flags: -
  *
- * @param[out] a0: pointer to output polynomial
+ * @param[out] a0: pointer to accumulator on which to add output
  * @param[in]  a1: byte array with seed of length CRHBYTES
  * @param[in]  a2: nonce
  * @param[in]  a3: pointer to gamma1_vec_const
  *
- * clobbered registers: a0, a4, t0-t6, w1-w2, w8
+ * clobbered registers: a1, t0-t3, w0-w6
  */
 .global poly_uniform_gamma1_dilithium
 poly_uniform_gamma1_dilithium:
@@ -2209,6 +2213,8 @@ _inner_poly_uniform_gamma1_dilithium:
 
     bn.and     w2, w2, w5 /* Mask unpacked coeffs to 18 bit */
     bn.subvm.8S w2, w4, w2 /* w2 <= gamma1_eta_const - w2 */
+    bn.lid     x0, 0(t1)
+    bn.addvm.8S w2, w0, w2
     bn.sid     t2, 0(t1++)
     ret
 #elif GAMMA1 == (1 << 19)
@@ -2299,6 +2305,8 @@ _inner_poly_uniform_gamma1_dilithium:
 
     bn.and     w2, w2, w5 /* Mask unpacked coeffs to 20 bit */
     bn.subvm.8S w2, w4, w2 /* w2 <= gamma1_eta_const - w2 */
+    bn.lid     x0, 0(t1)
+    bn.addvm.8S w2, w0, w2
     bn.sid     t2, 0(t1++)
     ret
 #endif

--- a/sw/otbn/crypto/mldsa/sign_dilithium.s
+++ b/sw/otbn/crypto/mldsa/sign_dilithium.s
@@ -229,28 +229,28 @@ sign_dilithium:
     #define STACK_TMP  -2240 /* Prev - 1024 */
     #define STACK_CP  -3264 /* Prev - 1024 */
 #if DILITHIUM_MODE == 2
-    #define STACK_W1  -7360 /* Prev - K*1024 */
-    #define STACK_W0  -11456 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -11456 /* Prev */
-    #define STACK_CTX  -11460 /* Prev - 4 */
-    #define INIT_SP -11488
-    #define STACK_SIZE 11616
+    #define STACK_W1  -3392 /* Prev - K*32 */
+    #define STACK_W0  -7488 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -7488 /* Prev */
+    #define STACK_CTX  -7492 /* Prev - 4 */
+    #define INIT_SP -7520
+    #define STACK_SIZE 7648
 
 #elif DILITHIUM_MODE == 3
-    #define STACK_W1  -9408 /* Prev - K*1024 */
-    #define STACK_W0  -15552 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -15552 /* Prev */
-    #define STACK_CTX  -15556 /* Prev - 4 */
-    #define INIT_SP -15584
-    #define STACK_SIZE 15712
+    #define STACK_W1  -3456 /* Prev - K*32 */
+    #define STACK_W0  -9600 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -9600 /* Prev */
+    #define STACK_CTX  -9604 /* Prev - 4 */
+    #define INIT_SP -9632
+    #define STACK_SIZE 9760
 
 #elif DILITHIUM_MODE == 5
-    #define STACK_W1  -11456 /* Prev - K*1024 */
-    #define STACK_W0  -19648 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -19648 /* Prev */
-    #define STACK_CTX  -19652 /* Prev - 4 */
-    #define INIT_SP -19680
-    #define STACK_SIZE 19808
+    #define STACK_W1  -3520 /* Prev - K*32 */
+    #define STACK_W0  -11712 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -11712 /* Prev */
+    #define STACK_CTX  -11716 /* Prev - 4 */
+    #define INIT_SP -11744
+    #define STACK_SIZE 11872
 #endif
 
     /* Initialize the frame pointer */
@@ -515,7 +515,7 @@ _rej_sign_dilithium:
     /* Matrix-vector multiplication */
 
     /* Get destination pointer. */
-    li s1, STACK_W1
+    li s1, STACK_W0
     add s1, fp, s1
 
     /* Initialize destination to 0. */
@@ -526,7 +526,7 @@ _rej_sign_dilithium:
           bn.sid t0, 0(t1++)
         nop
 
-    /* Load the constant for resetting the w1 pointer. */
+    /* Load the constant for resetting the w pointer. */
     li s6, POLYVECK_BYTES
 
     /* Initialize the nonce for matrix expansion. This value should be
@@ -542,7 +542,7 @@ _rej_sign_dilithium:
          for j in 0..l-1:
            yj = ntt(y[j])
            for i in 0..k-1:
-             w1[i] += A[i][j] * yj
+             w[i] += A[i][j] * yj
     */
     .rept L
         /* Compute y[j], storing temporarily in the matrix poly buffer. */
@@ -573,15 +573,15 @@ _rej_sign_dilithium:
             add  a0, fp, a0
             li   a1, STACK_TMP
             add  a1, fp, a1
-            addi a2, s1, 0 /* *W1[i] */
-            /* Add A[i][j] * y[j] to w1[i]. */
+            addi a2, s1, 0 /* *w[i] */
+            /* Add A[i][j] * y[j] to w[i]. */
             jal  x1, poly_pointwise_acc_dilithium
-            /* Increment the w1 pointer. */
+            /* Increment the w pointer. */
             addi s1, s1, 1024
             /* Increment the row index by 1. */
             addi s4, s4, 256
         .endr
-        /* Reset w1 pointer. */
+        /* Reset w pointer. */
         sub  s1, s1, s6
         /* Increment the column index in the nonce by one. */
         addi s4, s4, 1
@@ -589,8 +589,8 @@ _rej_sign_dilithium:
         andi s4, s4, 255
     .endr
 
-    /* Inverse NTT on w1 */
-    li  a0, STACK_W1
+    /* Inverse NTT on w */
+    li  a0, STACK_W0
     add a0, fp, a0
     la  a1, twiddles_inv
 
@@ -609,34 +609,6 @@ _rej_sign_dilithium:
         pop \reg
     .endr
 
-    /* Load source pointers */
-
-    /* Decompose */
-    li   a2, STACK_W1 /* Input */
-    add  a2, fp, a2
-    addi a1, a2, 0    /* Output inplace */
-    li   a0, STACK_W0 /* Output */
-    add  a0, fp, a0
-
-    LOOPI K, 2
-        jal x1, poly_decompose_dilithium
-        nop
-
-    /* Pack w1 */
-    li  a1, STACK_W1 /* Get *w1 */
-    add a1, fp, a1
-    /* Use an offset of 16 to accomodate for the alignment hack for CTILDE */
-    li  a0, STACK_SIG
-    add a0, fp, a0
-    lw  a0, 0(a0) /* Get *sig */
-#if CTILDEBYTES == 48
-    addi a0, a0, 16
-#endif
-
-    LOOPI K, 2
-        jal x1, polyw1_pack_dilithium
-        nop
-
     /* Random oracle */
     /* Initialize a SHAKE256 operation. */
     addi  a1, zero, CRHBYTES
@@ -652,25 +624,55 @@ _rej_sign_dilithium:
     add a0, fp, a0
     jal x1, keccak_send_message
 
-    /* Send packed w1 to the Keccak core. */
-    /* set packed w1 length to K*POLYW1_PACKEDBYTES */
-    li a1, 0
-    LOOPI K, 1
-        addi a1, a1, POLYW1_PACKEDBYTES
-    /* Use an offset of 16 to accomodate for the alignment hack for CTILDE */
-    li   a0, STACK_SIG
-    add  a0, fp, a0
-    lw   a0, 0(a0) /* get *sig */
-    addi s0, a0, 0 /* save a0 */
+    /* Save some pointers for loop. */
+    li  s0, STACK_W0
+    add s0, fp, s0
+    li  s1, STACK_W1
+    add s1, fp, s1
+    li  s4, STACK_TMP
+    add s4, fp, s4
+
+    /* Get the pointer to the signature (used as tmp buffer for packed w1). */
+    li  s2, STACK_SIG
+    add s2, fp, s2
+    lw  s2, 0(s2) /* Get *sig */
+    addi s3, s2, 0 /* Save *sig. */
 #if CTILDEBYTES == 48
-    addi a0, a0, 16
+    /* Use an offset of 16 to get an aligned buffer (alignment hack for CTILDE). */
+    addi s2, s2, 16
 #endif
-    jal  x1, keccak_send_message
+
+    /* This loop:
+         - decomposes each polynomial w[i] into w0[i] and w1[i]
+         - packs w1[i] and sends it to the Keccak core
+         - records the nonzero high bits of w1[i] for later use
+
+       Afterwards, the w1[i] value can be discarded, so we do not need to keep
+       two w-sized polyvecs in scope at once. */
+    .rept K
+        /* Decompose w and store w0 in-place, w1 in tmp. */
+        addi   a0, s0, 0
+        addi   a1, s4, 0
+        addi   a2, s0, 0
+        jal    x1, poly_decompose_dilithium
+        /* Pack w1. */
+        addi   a0, s2, 0
+        addi   a1, s4, 0
+        jal    x1, polyw1_pack_dilithium
+        /* Send packed w1 to the Keccak core. */
+        addi   a0, s2, 0
+        li     a1, POLYW1_PACKEDBYTES
+        jal    x1, keccak_send_message
+        /* Calculate the coefficients of w1 that are nonzero mod q, and store them. */
+        addi   a0, s4, 0
+        jal    x1, poly_nonzero_encode_dilithium
+        bn.sid x0, 0(s1++)
+        /* Increment w pointer. */
+        addi s0, s0, 1024
+    .endr
 
     /* Setup WDR */
     li t1, 8
-    /* Restore a0*/
-    addi    a0, s0, 0
 
     /* Read first 32 bytes of digest. */
     bn.wsrr w8, 0xA
@@ -681,32 +683,32 @@ _rej_sign_dilithium:
 #if CTILDEBYTES == 32
     /* Store first 32 bytes into temp buffer and signature. */
     bn.sid  t1, 0(t0)
-    bn.sid  t1, 0(a0)
+    bn.sid  t1, 0(s3)
 #elif CTILDEBYTES == 48
     /* Store first 32 bytes into temp buffer and (unaligned) signature. */
     bn.sid  t1, 0(t0)
     LOOPI 8, 4
         lw t2, 0(t0)
-        sw t2, 0(a0)
+        sw t2, 0(s3)
         addi t0, t0, 4
-        addi a0, a0, 4
+        addi s3, s3, 4
 
     /* Read 32 more bytes and store 16 of them. */
     bn.wsrr w8, 0xA
     bn.sid  t1, 0(t0)
     LOOPI 4, 4
         lw t2, 0(t0)
-        sw t2, 0(a0)
+        sw t2, 0(s3)
         addi t0, t0, 4
-        addi a0, a0, 4
+        addi s3, s3, 4
 #elif CTILDEBYTES == 64
     /* Store first 32 bytes into temp buffer and signature. */
     bn.sid  t1, 0(t0)
-    bn.sid  t1, 0(a0)
+    bn.sid  t1, 0(s3)
     /* Store 32 more bytes (both places). */
     bn.wsrr w8, 0xA
     bn.sid  t1, 32(t0)
-    bn.sid  t1, 32(a0)
+    bn.sid  t1, 32(s3)
 #endif
 
     /* Finish the SHAKE-256 operation. */
@@ -980,10 +982,10 @@ _rej_sign_dilithium:
         bne  a0, zero, _rej_sign_dilithium
 
         /* h[i] = make_hint(w0[i], w1[i]) */
-        addi a0, s1, 0
-        addi a1, s3, 0
-        addi a2, s5, 0
-        jal  x1, poly_make_hint_dilithium
+        addi   a0, s1, 0
+        addi   a1, s3, 0
+        bn.lid x0, 0(s5++)
+        jal    x1, poly_make_hint_dilithium
 
         /* Update the coefficient sum accumulator (saving previous value). */
         add  a2, s4, 0
@@ -1004,12 +1006,8 @@ _rej_sign_dilithium:
         /* Increment w0[i] pointer. */
         addi s3, s3, 1024
 
-        /* Increment w1[i] pointer. */
-        addi s5, s5, 1024
-
         /* Increment i. */
         addi s6, s6, 1
-
     .endr
 
     /* Return success and signature length */

--- a/sw/otbn/crypto/mldsa/sign_dilithium.s
+++ b/sw/otbn/crypto/mldsa/sign_dilithium.s
@@ -224,33 +224,33 @@ sign_dilithium:
     #define STACK_KEY -192 /* Prev - 32 */
         #define STACK_RHOPRIME -192 /* Prev */
     #define STACK_Y  -1216 /* Prev - 1024 */
-        #define STACK_S1  -1216 /* Prev */
-        #define STACK_H   -1216 /* Prev */
+        #define STACK_CP  -1216 /* Prev */
     #define STACK_TMP  -2240 /* Prev - 1024 */
-    #define STACK_CP  -3264 /* Prev - 1024 */
+        #define STACK_H   -2240 /* Prev */
+        #define STACK_S1  -2240 /* Prev */
 #if DILITHIUM_MODE == 2
-    #define STACK_W1  -3392 /* Prev - K*32 */
-    #define STACK_W0  -7488 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -7488 /* Prev */
-    #define STACK_CTX  -7492 /* Prev - 4 */
-    #define INIT_SP -7520
-    #define STACK_SIZE 7648
+    #define STACK_W1  -2368 /* Prev - K*32 */
+    #define STACK_W0  -6464 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -6464 /* Prev */
+    #define STACK_CTX  -6468 /* Prev - 4 */
+    #define INIT_SP -6496
+    #define STACK_SIZE 6624
 
 #elif DILITHIUM_MODE == 3
-    #define STACK_W1  -3456 /* Prev - K*32 */
-    #define STACK_W0  -9600 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -9600 /* Prev */
-    #define STACK_CTX  -9604 /* Prev - 4 */
-    #define INIT_SP -9632
-    #define STACK_SIZE 9760
+    #define STACK_W1  -2432 /* Prev - K*32 */
+    #define STACK_W0  -8576 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -8576 /* Prev */
+    #define STACK_CTX  -8580 /* Prev - 4 */
+    #define INIT_SP -8608
+    #define STACK_SIZE 8736
 
 #elif DILITHIUM_MODE == 5
-    #define STACK_W1  -3520 /* Prev - K*32 */
-    #define STACK_W0  -11712 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -11712 /* Prev */
-    #define STACK_CTX  -11716 /* Prev - 4 */
-    #define INIT_SP -11744
-    #define STACK_SIZE 11872
+    #define STACK_W1  -2496 /* Prev - K*32 */
+    #define STACK_W0  -10688 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -10688 /* Prev */
+    #define STACK_CTX  -10692 /* Prev - 4 */
+    #define INIT_SP -10720
+    #define STACK_SIZE 10848
 #endif
 
     /* Initialize the frame pointer */
@@ -534,6 +534,9 @@ _rej_sign_dilithium:
        for entry A[i][j]. */
     li s4, 0
 
+    /* Load a constant pointer to the zero wide register. */
+    li s5, 31
+
     /* Compute A * y, computing the values for A and y on the fly.
 
        We compute column-wise so that we genearate elements of y only once; in
@@ -545,7 +548,12 @@ _rej_sign_dilithium:
              w[i] += A[i][j] * yj
     */
     .rept L
-        /* Compute y[j], storing temporarily in the matrix poly buffer. */
+        /* Zero the buffer for y[j]. */
+        li   a0, STACK_Y
+        add  a0, fp, a0
+        loopi 32, 1
+          bn.sid s5, 0(a0++)
+        /* Compute y[j]. */
         li   a0, STACK_Y
         add  a0, fp, a0
         li   a1, STACK_RHOPRIME
@@ -778,19 +786,14 @@ _rej_sign_dilithium:
         addi a0, s2, 0
         la  a1, twiddles_inv
         jal x1, intt_dilithium
-        /* Sample the next value of y and reuse s1 buffer to store it. */
-        addi a0, s1, 0
+        /* Sample the next value of y and add it to z. */
+        addi a0, s2, 0
         addi a1, s3, 0
         addi a2, s8, 0
         addi a3, s10, 0
         jal  x1, poly_uniform_gamma1_dilithium
         /* Update the nonce for y. */
         addi s8, a2, 1
-        /* z[i] += y[i] */
-        addi a0, s1, 0
-        addi a1, s2, 0
-        addi a2, s2, 0
-        jal x1, poly_add_dilithium
         /* reduce32(z) to move to mod^{+-} for bound check */
         addi a0, s2, 0
         addi a1, s2, 0

--- a/sw/otbn/crypto/tests/mldsa/dilithium_sign_test.s
+++ b/sw/otbn/crypto/tests/mldsa/dilithium_sign_test.s
@@ -34,7 +34,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1312
 #define CRYPTO_SECRETKEYBYTES 2560
 #define CRYPTO_BYTES 2420
-#define STACK_SIZE 7648 /* minimum 8KB */
+#define STACK_SIZE 6624 /* minimum 7KB */
 
 #elif DILITHIUM_MODE == 3
 #define K 6
@@ -50,7 +50,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1952
 #define CRYPTO_SECRETKEYBYTES 4032
 #define CRYPTO_BYTES 3309
-#define STACK_SIZE 9760 /* minimum 10KB */
+#define STACK_SIZE 8736 /* minimum 9KB */
 
 #elif DILITHIUM_MODE == 5
 #define K 8
@@ -66,7 +66,7 @@
 #define CRYPTO_PUBLICKEYBYTES 2592
 #define CRYPTO_SECRETKEYBYTES 4896
 #define CRYPTO_BYTES 4627
-#define STACK_SIZE 11872 /* minimum 12KB */
+#define STACK_SIZE 10848 /* minimum 11KB */
 
 #endif
 

--- a/sw/otbn/crypto/tests/mldsa/dilithium_sign_test.s
+++ b/sw/otbn/crypto/tests/mldsa/dilithium_sign_test.s
@@ -34,7 +34,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1312
 #define CRYPTO_SECRETKEYBYTES 2560
 #define CRYPTO_BYTES 2420
-#define STACK_SIZE 11616 /* minimum 12KB */
+#define STACK_SIZE 7648 /* minimum 8KB */
 
 #elif DILITHIUM_MODE == 3
 #define K 6
@@ -50,7 +50,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1952
 #define CRYPTO_SECRETKEYBYTES 4032
 #define CRYPTO_BYTES 3309
-#define STACK_SIZE 15712 /* minimum 16KB */
+#define STACK_SIZE 9760 /* minimum 10KB */
 
 #elif DILITHIUM_MODE == 5
 #define K 8
@@ -66,7 +66,7 @@
 #define CRYPTO_PUBLICKEYBYTES 2592
 #define CRYPTO_SECRETKEYBYTES 4896
 #define CRYPTO_BYTES 4627
-#define STACK_SIZE 19808 /* minimum 20KB */
+#define STACK_SIZE 11872 /* minimum 12KB */
 
 #endif
 


### PR DESCRIPTION
- The first commit compresses `w1` to save {4,6,8}kB for Dilithium{2,3,5} at about a 2% performance cost (exact numbers in the commit message).
- The second commit rearranges polynomial buffers so that we only need 2 instead of 3 to save a further 1kB for all parameters, at approximately a 0.1% performance cost.

As discussed in https://github.com/zerorisc/expo-otbn-pqc/pull/18#issuecomment-3135197693, this brings sign stack usage down enough to accommodate first-order masked ML-DSA-65, so I'll probably stop the optimizations here for now and only try more aggressive measures if it looks like we need second-order masking or masking for ML-DSA-87 down the line. For now I just wanted to make sure 32kB would be enough, and get certainty on how much the memory optimizations would impact signing performance.