### PR TITLE
[otbn] Implemented AppIntf for OTBN to KMAC connection

### DIFF
--- a/hw/ip/otbn/data/csr.yml
+++ b/hw/ip/otbn/data/csr.yml
@@ -123,7 +123,9 @@
   address: 0x7f3
   doc: |
     Partial write msg register used as a byte-mask for the msg being written into the internal MSG FIFO.
-    The value of this CSR should be contiguous ex.) 32'h0000_ffff is valid and 32'h0000_feff is not.
+    The value should be the decimal number of bytes valid for the msg to be written ex.) 32 for every byte valid.
+    Conversion to a contiguous mask like 32'h0000_ffff are done internally.
+    Additionally, the register is reset to a default value of 32 at the start/end of any transaction.
 
 - name: rnd
   address: 0xfc0

--- a/hw/ip/otbn/data/csr.yml
+++ b/hw/ip/otbn/data/csr.yml
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -95,6 +96,32 @@
   doc: |
     Write to this CSR to begin a request to fill the RND cache.
     Always reads as 0.
+
+- name: kmac_cfg
+  address: 0x7d9
+  doc: |
+    Write to this CSR to set the configuration for KMAC msg.
+    Bit  [31]   Cfg Done
+    Bits [19:8] Number of 64-bit words in message
+    Bits [7:5]  Number of bytes in final word
+    Bits [4:2]  Keccak Strength
+    Bits [1:0]  SHA3 Mode
+    This CSR is mapped to the KMAC CFG WSR.
+
+- name: kmac_status
+  address: 0x7e2
+  read-only: true
+  doc: |
+    Contains status bits for KMAC operations and return digest
+    Bit [2]   Digest error
+    Bit [1]   KMAC Ready
+    Bit [0]   Digest Done
+
+- name: kmac_partial_write
+  address: 0x7f3
+  doc: |
+    Partial write msg register used as a byte-mask for the msg being written into the internal MSG FIFO.
+    The value of this CSR should be contiguous ex.) 32'h0000_ffff is valid and 32'h0000_feff is not.
 
 - name: rnd
   address: 0xfc0

--- a/hw/ip/otbn/data/csr.yml
+++ b/hw/ip/otbn/data/csr.yml
@@ -113,6 +113,8 @@
   read-only: true
   doc: |
     Contains status bits for KMAC operations and return digest
+    Bit [4]   MSG Undersized Error
+    Bit [3]   MSG Oversized Error
     Bit [2]   Digest error
     Bit [1]   KMAC Ready
     Bit [0]   Digest Done

--- a/hw/ip/otbn/data/wsr.yml
+++ b/hw/ip/otbn/data/wsr.yml
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -67,3 +68,20 @@
     Bits [127:0] contain bits [383:256] of share 1 of the 384b OTBN sideload key provided by the [Key Manager](../keymgr/README.md).
 
     A `KEY_INVALID` software error is raised on read if the Key Manager has not provided a valid key.
+
+- name: kmac_cfg
+  address: 8
+  doc: |
+    Contains the configuration bits for sending KMAC messages.
+    Also visible as a kmac_cfg CSR.
+
+- name: kmac_msg
+  address: 9
+  doc: |
+    The kmac msg to send over AppIntf.
+    A byte mask is applied to the msg from the kmac_partial_write WSR value before being written into the internal MSG FIFO.
+
+- name: kmac_digest
+  address: 10
+  doc: |
+    Return digest from AppIntf.

--- a/hw/ip/otbn/dv/otbnsim/sim/csr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/csr.py
@@ -1,8 +1,9 @@
 # Copyright lowRISC contributors (OpenTitan project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
 # Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192).
 # Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors.
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
 
 
 from .flags import FlagGroups
@@ -23,6 +24,7 @@ class CSRFile:
         self._known_indices.add(0x7d8)  # RND_PREFETCH
         self._known_indices.add(0x7d9)  # KMAC_CFG
         self._known_indices.add(0x7e2)  # KMAC_STATUS
+        self._known_indices.add(0x7f3)  # KMAC_PARTIAL_WRITE
         self._known_indices.add(0xfc0)  # RND
         self._known_indices.add(0xfc1)  # URND
 
@@ -80,6 +82,10 @@ class CSRFile:
             digest_n = idx - 0x7eb
             return self._get_field(digest_n, 32, wsrs.KMAC_DIGEST_SHARE1.read_unsigned())
 
+        if idx == 0x7f3:
+            # KMAC_PARTIAL_WRITE
+            return 0
+
         if idx == 0xfc0:
             # RND register
             return wsrs.RND.read_u32()
@@ -129,6 +135,10 @@ class CSRFile:
         if 0x7e3 <= idx <= 0x7f2:
             # KMAC_DIGEST_SHARE0 and _SHARE1
             return
+
+        if idx == 0x7f3:
+            wsrs.KMAC_PARTIAL_WRITE.write_unsigned(value)
+            return 0
 
         if idx == 0xfc0:
             # RND register (which ignores writes)

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -1,8 +1,9 @@
 # Copyright lowRISC contributors (OpenTitan project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
 # Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192).
 # Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors.
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
 
 
 from typing import Dict, Iterator, Optional
@@ -574,6 +575,16 @@ class CSRRW(OTBNInsn):
             # value is available, it returns True.
             while not state.wsrs.RND.request_value():
                 # There's a pending EDN request. Stall for a cycle.
+                yield None
+
+        if self.csr == 0x7f3:
+            # A write to KMAC_PW might stall, if there is a pending write
+            # to the AppIntf FIFO inside OTBN Bignum ALU
+            if DEBUG_KMAC:
+                eprint("\tBNWSRW FOR KMAC PARTIAL WRITE REGISTER")
+            while state.wsrs.KMAC_MSG.pending_write():
+                if DEBUG_KMAC:
+                    eprint("\tBNWSRW to KMAC_PW stall")
                 yield None
 
         # At this point, the CSR is either ready or unneeded. Read it if
@@ -1620,14 +1631,14 @@ class BNWSRW(OTBNInsn):
 
     def execute(self, state: OTBNState) -> None:
         if DEBUG_KMAC:
-            print("\tRun BNWSRW")
+            eprint(f"\tRun BNWSRW Address {self.wsr}")
         dest_wsrs = state.wsrs._by_idx[self.wsr]
         if self.wsr == 0x9:
             # A write to KMAC_MSG might stall, if the register has not yet pushed
             # all its contents to the FIFO connected to the KMAC app interface.
             while not state.wsrs.KMAC_MSG.request_write():
                 if DEBUG_KMAC:
-                    print("\tBNWSRW to KMAC_MSG stall")
+                    eprint("\tBNWSRW to KMAC_MSG stall")
                 dest_wsrs.stalled = True
                 yield None
 

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -1,16 +1,23 @@
 # Copyright lowRISC contributors (OpenTitan project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
 # Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192).
 # Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors.
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
 
 
+import sys
 from typing import List, Optional, Sequence, Tuple
 from Crypto.Hash import cSHAKE128, cSHAKE256, SHAKE128, SHAKE256, SHA3_224, \
     SHA3_256, SHA3_384, SHA3_512
 from .trace import Trace
 from .ext_regs import OTBNExtRegs
 DEBUG_KMAC = False
+
+
+def kmac_debug_print(text):
+    if DEBUG_KMAC:
+        print(text, file=sys.stderr)
 
 
 class TraceWSR(Trace):
@@ -396,7 +403,7 @@ class KmacBlock:
     # FIFO within OTBN that waits to send message data over the application
     # interface. Without this we'd have to stall on every message WSR write
     # while we wait to send data to KMAC.
-    _APP_INTF_FIFO_SIZE_BYTES = 32
+    _APP_INTF_FIFO_SIZE_BYTES = 64
 
     # After setting the KMAC_CFG register, it takes two cycles until the KMAC_STATUS
     # register changes its value to ready.
@@ -422,6 +429,7 @@ class KmacBlock:
         self._app_intf_ready_pending_ctr = None
         self._app_intf_fifo_ready = True
         self._app_intf_fifo_ready_next = True
+        self._app_intf_fifo_flush = False
         self._app_intf_last = False
         self._msg_fifo_flush_ctr = 0
         self._msg_fifo_flush = False
@@ -456,6 +464,7 @@ class KmacBlock:
         self._app_intf_last = False
         self._app_intf_fifo_ready = True
         self._app_intf_fifo_ready_next = True
+        self._app_intf_fifo_flush = False
         self._core_pending_bytes = 0
         self._core_pending_bytes_next = 0
         self._msg_len = 0
@@ -477,8 +486,8 @@ class KmacBlock:
         self._skip_digest_shift_cycle = False
 
     def set_configuration(self, mode: int, strength: int, msg_len: int) -> None:
-        if DEBUG_KMAC:
-            print(f"\tSetting KMAC config: mode = {mode}, strength = {strength}, len = {msg_len}")
+        kmac_debug_print(f"\tSetting KMAC config: mode = {mode}, \
+                         strength = {strength}, len = {msg_len}")
         self._mode = mode
         self._strength = strength
         self._msg_len = msg_len
@@ -497,8 +506,7 @@ class KmacBlock:
     def message_done(self) -> None:
         '''Indicate that the message input is done.'''
         # Don't issue the `process` command yet; wait for FIFOs to clear.
-        if DEBUG_KMAC:
-            print("\tKMAC message done, pending process")
+        kmac_debug_print("\tKMAC message done, pending process")
         self._pending_process = True
 
     def is_idle(self) -> bool:
@@ -511,14 +519,13 @@ class KmacBlock:
         return self._status == self._STATUS_SQUEEZE
 
     def digest_ready(self) -> bool:
-        if DEBUG_KMAC:
-            print(f"\tKMAC Digest Ready Req: \
-                  autowrite={self._automatically_write_digest} \
-                  shift={self._shift_digest_reg} \
-                  permute={self._new_permutation} \
-                  read={self._digest_read} ready={self._digest_ready} \
-                  read_offset={self._read_offset} \
-                  leftover={self._leftover_digest_bytes}")
+        kmac_debug_print(f"\tKMAC Digest Ready Req: \
+                        autowrite={self._automatically_write_digest} \
+                        shift={self._shift_digest_reg} \
+                        permute={self._new_permutation} \
+                        read={self._digest_read} ready={self._digest_ready} \
+                        read_offset={self._read_offset} \
+                        leftover={self._leftover_digest_bytes}")
         if self._automatically_write_digest:
             if self._digest_ready:
                 self._digest_read = True
@@ -613,7 +620,13 @@ class KmacBlock:
         return self._APP_INTF_FIFO_SIZE_BYTES - len(self._app_intf_fifo)
 
     def app_intf_fifo_ready(self) -> bool:
-        return self._app_intf_fifo_ready and (len(self._app_intf_fifo) == 0)
+        # If the AppIntf FIFO is ready and the current size of the contents is less than or equal
+        # to 8B we can absorb
+        # FIFO size is 64B allowing for a full length word even if there is 8B or less
+        return (
+            self._app_intf_fifo_ready
+            and len(self._app_intf_fifo) <= self._APP_INTF_BYTES_PER_CYCLE
+        )
 
     def write_to_app_intf_fifo(self, msg: bytes) -> bool:
         '''Appends new message data to an ongoing hashing operation.
@@ -623,25 +636,29 @@ class KmacBlock:
         '''
         if not self.is_absorbing():
             raise ValueError(f'KMAC: Cannot write in {self._status} status.')
-        if DEBUG_KMAC:
-            print(f"\tAttempting write to App FIFO: \
-                  ready = {self.app_intf_fifo_ready()}, \
-                  fifo len = {len(self._app_intf_fifo)}")
-        if not self.app_intf_fifo_ready() or len(self._app_intf_fifo) != 0:
+        kmac_debug_print(f"\tAttempting write to App FIFO: \
+                        ready = {self.app_intf_fifo_ready()}, \
+                        fifo len = {len(self._app_intf_fifo)}")
+        # If there is more than 8B we can not yet write
+        if (
+            not self.app_intf_fifo_ready()
+            or len(self._app_intf_fifo) > self._APP_INTF_BYTES_PER_CYCLE
+        ):
             return False
         self._app_intf_fifo += msg
         return True
 
     def _start_keccak_core(self, absorbed) -> None:
-        if DEBUG_KMAC:
-            print("\tStarting round logic")
+        kmac_debug_print("\tStarting round logic")
         if absorbed:
             self._core_cycles_remaining = self._KECCAK_NUM_ROUNDS * \
                 self._KECCAK_CYCLES_PER_ROUND + \
                 self._KECCAK_LATENCY_DIGEST_EXPOSED
+            kmac_debug_print(f"In Absorbed | remaining_cycles = {self._core_cycles_remaining}")
         else:
             self._core_cycles_remaining = self._KECCAK_NUM_ROUNDS * \
                 self._KECCAK_CYCLES_PER_ROUND + self._KECCAK_LATENCY_DONE
+            kmac_debug_print(f"Not Absorbed | remaining_cycles = {self._core_cycles_remaining}")
 
     def _core_is_busy(self) -> None:
         return self._core_cycles_remaining is not None and self._core_cycles_remaining > 0
@@ -663,8 +680,7 @@ class KmacBlock:
         if not self.is_absorbing():
             raise ValueError('KMAC: Cannot issue `process` command in '
                              f'{self._status} status.')
-        if DEBUG_KMAC:
-            print("\tKMAC START PROCESS")
+        kmac_debug_print("\tKMAC START PROCESS")
         self._status = self._STATUS_SQUEEZE
         self._start_keccak_core(True)
 
@@ -680,6 +696,7 @@ class KmacBlock:
         if not self.is_squeezing():
             raise ValueError('KMAC: Cannot issue `run` command in '
                              f'{self._status} status.')
+        kmac_debug_print("\tKMAC RUN PROCESS")
         self._start_keccak_core(True)
         self._read_offset = 0
 
@@ -697,19 +714,18 @@ class KmacBlock:
         if self.is_idle():
             return
 
-        if DEBUG_KMAC:
-            print(f"CYCLE - Stepping KMAC, \
-                  remaining_cycles = {self._core_cycles_remaining}, \
-                  core_pending_bytes = {self._core_pending_bytes}, \
-                  available = {self._rate_bytes - self._core_pending_bytes} \
-                  pending_process = {self._pending_process}, \
-                  digest_req_ctr = {self._digest_request_ctr}")
+        kmac_debug_print(f"CYCLE - Stepping KMAC, \
+                        remaining_cycles = {self._core_cycles_remaining}, \
+                        core_pending_bytes = {self._core_pending_bytes}, \
+                        available = {self._rate_bytes - self._core_pending_bytes} \
+                        pending_process = {self._pending_process}, \
+                        digest_req_ctr = {self._digest_request_ctr}, \
+                        MSG FIFO SIZE = {len(self._msg_fifo)}")
 
         if self._app_intf_ready_pending_ctr is not None:
             self._app_intf_ready_pending_ctr += 1
             if self._app_intf_ready_pending_ctr == self._APP_INTF_READY_LATENCY:
-                if DEBUG_KMAC:
-                    print("\tKMAC App Iface Ready")
+                kmac_debug_print("\tKMAC App Iface Ready")
                 self._app_intf_ready = True
                 self._app_intf_ready_pending_ctr = None
 
@@ -725,8 +741,7 @@ class KmacBlock:
             if self._msg_fifo_flush:
                 self._msg_fifo_flush_ctr += 1
             if len(self._msg_fifo) >= absorb_rate:
-                if DEBUG_KMAC:
-                    print(f"\tMSG FIFO -> STATE: Absorbing 64-bit: \
+                kmac_debug_print(f"\tMSG FIFO -> STATE: Absorbing 64-bit: \
                           {self._msg_fifo[:absorb_rate][::-1].hex()}")
                 # Absorb a new chunk of the message.
                 self._core_pending_bytes_next = self._core_pending_bytes + absorb_rate
@@ -745,8 +760,7 @@ class KmacBlock:
                     # "hidden" and we only have one additional cycle of effective delay
                     # for flusing the fifo.
                     if self._msg_fifo_flush_ctr > 0:
-                        if DEBUG_KMAC:
-                            print(f"\tMSG FIFO -> STATE: \
+                        kmac_debug_print(f"\tMSG FIFO -> STATE: \
                                   Absorbing last data (smaller than word): \
                                   {self._msg_fifo[:absorb_rate][::-1].hex()}, \
                                   flush_ctr = {self._msg_fifo_flush_ctr}")
@@ -757,12 +771,10 @@ class KmacBlock:
                         self._msg_fifo = bytes()
                 elif not self._msg_fifo_packer_flushed and self._msg_fifo_flush_ctr <= 2 \
                         and not self._padding_only:
-                    if DEBUG_KMAC:
-                        print("\tFlushing MSG FIFO PACKER")
+                    kmac_debug_print("\tFlushing MSG FIFO PACKER")
                     self._msg_fifo_packer_flushed = True
                 elif not self._msg_fifo_flushed and not self._padding_only:
-                    if DEBUG_KMAC:
-                        print("\tFlushing MSG FIFO")
+                    kmac_debug_print("\tFlushing MSG FIFO")
                     self._msg_fifo_flushed = True
                 elif self._core_pending_bytes < self._rate_bytes and not self._core_is_busy():
                     # model padding cycles
@@ -770,24 +782,52 @@ class KmacBlock:
                     self._msg_fifo_flush = False
                     padding_len = absorb_rate - (self._core_pending_bytes % 8)
                     self._core_pending_bytes_next = self._core_pending_bytes + padding_len
-                    if DEBUG_KMAC:
-                        print("\tApply Padding")
+                    kmac_debug_print(f"\tApply Padding with Len {padding_len}")
 
         # APP FIFO -> MSG FIFO
         self._msg_fifo_flush = self._pending_process
         if self._app_intf_last:
             self._app_intf_ready = False
+
+        # The fifo will be ready in the next clock cycle if there is 8B or less
+        if len(self._app_intf_fifo) <= self._APP_INTF_BYTES_PER_CYCLE:
+            kmac_debug_print("\tAPP INTF FIFO LESS THAN ONE WORD IN NEXT STEP")
+            self._app_intf_fifo_ready_next = True
+        else:
+            self._app_intf_fifo_ready_next = False
+
         if msg_fifo_write_ready and not self._msg_fifo_packer_flushing:
             # Pass data from the application interface FIFO to the message FIFO.
             nbytes = min(len(self._app_intf_fifo), self._APP_INTF_BYTES_PER_CYCLE, self._msg_len)
-            if DEBUG_KMAC and nbytes > 0:
-                print(f"\tAPP FIFO -> MSG FIFO: Absorbing {nbytes} \
-                      bytes: \
-                      {hex(int.from_bytes(self._app_intf_fifo[:nbytes], 'little'))}, \
-                      size of contents in MSG FIFO before new data: {len(self._msg_fifo)}")
-            self._msg_fifo += self._app_intf_fifo[:nbytes]
-            self._app_intf_fifo = self._app_intf_fifo[nbytes:]
-            self._msg_len -= nbytes
+            if nbytes >= self._APP_INTF_BYTES_PER_CYCLE:
+                kmac_debug_print(f"\tAPP FIFO -> MSG FIFO: Absorbing {nbytes} \
+                            bytes: \
+                            {hex(int.from_bytes(self._app_intf_fifo[:nbytes], 'little'))}, \
+                            size of contents in MSG FIFO before new data: {len(self._msg_fifo)}")
+            if nbytes >= self._APP_INTF_BYTES_PER_CYCLE:
+                self._msg_fifo += self._app_intf_fifo[:nbytes]
+                self._app_intf_fifo = self._app_intf_fifo[nbytes:]
+                self._msg_len -= nbytes
+
+            elif (self._app_intf_fifo_flush and nbytes < self._APP_INTF_BYTES_PER_CYCLE):
+                kmac_debug_print(f"\tAPP FIFO -> MSG FIFO: Absorbing {nbytes} \
+                            bytes: \
+                            {hex(int.from_bytes(self._app_intf_fifo[:nbytes], 'little'))}, \
+                            size of contents in MSG FIFO before new data: {len(self._msg_fifo)}")
+                self._msg_fifo += self._app_intf_fifo[:nbytes]
+                self._app_intf_fifo = self._app_intf_fifo[nbytes:]
+                self._msg_len -= nbytes
+                self._app_intf_fifo_flush = False
+
+            # Flushing the APP FIFO has an extra clock cycle to read
+            elif (
+                self._msg_len < self._APP_INTF_BYTES_PER_CYCLE
+                and self._msg_len != 0
+                and len(self._app_intf_fifo) > 0
+            ):
+                self._app_intf_fifo_flush = True
+
+            kmac_debug_print(f"\tMSG FIFO SIZE: {len(self._msg_fifo)}")
         else:
             # Once the FIFO fills up completely, the packer must flush completely until it can
             # consume new data.
@@ -798,20 +838,13 @@ class KmacBlock:
             if self._msg_fifo_packer_flush_ctr == self._MSG_FIFO_PACKER_FLUSH_LATENCY:
                 self._msg_fifo_packer_flushing = False
                 self._msg_fifo_packer_flush_ctr = 0
-            if DEBUG_KMAC:
-                print(f"\tMSG FIFO FULL, flush ctr = {self._msg_fifo_packer_flush_ctr}")
+            kmac_debug_print(f"\tMSG FIFO FULL, flush ctr = {self._msg_fifo_packer_flush_ctr}")
         if self._msg_len == 0 and not self._app_intf_last:
-            if DEBUG_KMAC:
-                print("\tAPP FIFO last")
+            kmac_debug_print("\tAPP FIFO last")
             self.message_done()
             self._app_intf_last = True
+
         self._app_intf_fifo_ready = self._app_intf_fifo_ready_next
-        if len(self._app_intf_fifo) == 0:
-            if DEBUG_KMAC:
-                print("\tAPP INTF FIFO EMPTY IN NEXT STEP")
-            self._app_intf_fifo_ready_next = True
-        else:
-            self._app_intf_fifo_ready_next = False
 
         # Digest Register
         self._digest_ready = self._digest_ready_next
@@ -843,8 +876,7 @@ class KmacBlock:
         # Either step the core or check if we can start it.
         if self._core_is_busy():
             self._core_cycles_remaining -= 1
-            if DEBUG_KMAC:
-                print("\tProcessing")
+            kmac_debug_print("\tProcessing")
         elif self._core_pending_bytes == self._rate_bytes:
             self._start_keccak_core(False)
             self._core_pending_bytes = 0
@@ -854,8 +886,7 @@ class KmacBlock:
                 # the message fifo is needed.
                 self._padding_only = True
             if self._pending_process and not self._msg_fifo and self._padded:
-                if DEBUG_KMAC:
-                    print("\tStarting processing")
+                kmac_debug_print("\tStarting processing")
                 # Just finished padding; send the process command.
                 self._process()
                 self._pending_process = False
@@ -888,6 +919,45 @@ class KmacBlock:
         return ret
 
 
+class KmacPartialWriteISPR(WSR):
+    '''Keccak partial write WSR
+
+    This register defines the numbeer of valid bytes in the
+    KmacMsgWSR register for writing partial words and STRB
+    on the KMAC Req AppIntf
+    '''
+    def __init__(self, name: str, kmac: KmacBlock):
+        super().__init__(name)
+        self._kmac = kmac
+        self._value = None
+        self._next_value = None
+
+    def read_unsigned(self) -> int:
+        return self._value
+
+    def read_mask(self) -> int:
+        if self._value is None:
+            return 32
+        elif self._value != (1 << self._value.bit_count()) - 1:
+            raise ValueError(f'Invalid mask size for KMAC_PARTIAL_WRITE: {self._value:#066x}')
+        return self._value.bit_count()
+
+    def write_unsigned(self, value: int) -> None:
+        self._next_value = value
+        self._pending_write = True
+
+    def commit(self) -> None:
+        if self._pending_write:
+            self._value = self._next_value
+            kmac_debug_print(f"\tREG -> KMAC_PARTIAL_WRITE reg: {hex(self._next_value)}")
+        super().commit()
+
+    def changes(self) -> Sequence[Trace]:
+        '''Return list of pending architectural changes'''
+        return ([TraceWSR(self.name, self._next_value)]
+                if self._pending_write else [])
+
+
 class KmacMsgWSR(WSR):
     '''Keccak message WSR: sends data to the KMAC hardware block.
 
@@ -901,12 +971,16 @@ class KmacMsgWSR(WSR):
     hold the data from a new write, the instruction stalls while it waits for
     space to become available.
     '''
-    def __init__(self, name: str, kmac: KmacBlock):
+    def __init__(self, name: str, kmac: KmacBlock, partial_ispr: KmacPartialWriteISPR):
         super().__init__(name)
         self._kmac = kmac
         self._pending_write_to_app_intf = False
+        self._pending_write_stall_pw = False
+        self._start_cycle_fifo_ready = False
+        self._prev_fifo_ready = True
         self._next_value = None
         self._value = None
+        self._partial_ispr = partial_ispr
 
     def read_unsigned(self) -> int:
         return 0
@@ -921,31 +995,35 @@ class KmacMsgWSR(WSR):
         self._pending_write = True
 
     def step(self) -> None:
-
         self._kmac.step()
-
+        kmac_debug_print("\tFETCHING STARTING FIFO STATUS")
+        self._pending_write_stall_pw = self._pending_write_to_app_intf
+        self._start_cycle_fifo_ready = self._kmac.app_intf_fifo_ready()
         # KMAC_MSG reg -> FIFO
         if self._pending_write_to_app_intf:
-            value_bytes = int.to_bytes(self._value, byteorder='little', length=32)
-            if DEBUG_KMAC:
-                print("\tPending write to App FIFO")
+            strb_len = self._partial_ispr.read_mask()
+            value_bytes = int.to_bytes(self._value, byteorder='little', length=32)[:strb_len]
+            kmac_debug_print("\tPending write to App FIFO")
             if self._kmac.write_to_app_intf_fifo(value_bytes):
-                if DEBUG_KMAC:
-                    print(f"\tKMAC_MSG -> APP FIFO: Writing {len(value_bytes)} bytes to App FIFO")
+                kmac_debug_print(f"\tKMAC_MSG -> APP FIFO: Writing \
+                                 {len(value_bytes)} bytes to App FIFO")
                 self._pending_write_to_app_intf = False
 
+    def pending_write(self) -> bool:
+        return self._pending_write_stall_pw
+
     def request_write(self) -> bool:
-        return self._kmac.app_intf_fifo_ready()
+        return self._start_cycle_fifo_ready
 
     def commit(self) -> None:
         # reg -> KMAC_MSG reg
         if self._pending_write:
             self._pending_write = False
             if self._next_value is not None:
-                if DEBUG_KMAC:
-                    print(f"\tREG -> KMAC_MSG reg: {hex(self._next_value)}")
+                kmac_debug_print(f"\tREG -> KMAC_MSG reg: {hex(self._next_value)}")
                 self._value = self._next_value
                 self._pending_write_to_app_intf = True
+                self._pending_write_stall_pw = True
             else:
                 # Silence F841 warning until we reimplement the KMAC interface.
                 value_bytes = None  # noqa: F841
@@ -975,6 +1053,7 @@ class KmacCfgWSR(WSR):
     def commit(self) -> None:
         if self._pending_write:
             self._value = self._next_value
+            kmac_debug_print(f"\tREG -> KMAC_MSG reg: {hex(self._next_value)}")
             if self._value == (1 << 31):
                 # config value to release KMAC app intf
                 # should be done once before OTBN yiels
@@ -1044,16 +1123,17 @@ class KmacDigestWSR(WSR):
         return self._has_value
 
     def request_value(self) -> bool:
-        '''Returns true if the full register value is ready.'''
+        '''Returns true if the full register value is ready,
+        but only one cycle after digest_ready() is asserted,
+        modeling the OTBN app_req.next behavior'''
         self._has_value = self._kmac.digest_ready()
-        if DEBUG_KMAC:
-            print(f"\tKMAC_DIGEST - Request value: {self._has_value}")
+
+        kmac_debug_print(f"\tKMAC_DIGEST - Request value: {self._has_value}")
         return self._has_value
 
     def read_unsigned(self) -> int:
         value = int.from_bytes(self._kmac.read(32), byteorder='little')
-        if DEBUG_KMAC:
-            print(f"\tRead value: {hex(value)}")
+        kmac_debug_print(f"\tRead value: {hex(value)}")
         return value
 
     def write_unsigned(self, value: int) -> None:
@@ -1086,10 +1166,11 @@ class WSRFile:
         self.KeyS0H = KeyWSR('KeyS0H', 256, self.KeyS0)
         self.KeyS1L = KeyWSR('KeyS1L', 0, self.KeyS1)
         self.KeyS1H = KeyWSR('KeyS1H', 256, self.KeyS1)
-        self.KMAC_MSG = KmacMsgWSR('KMAC_MSG', self.Kmac)
         self.KMAC_CFG = KmacCfgWSR('KMAC_CFG', self.Kmac)
         self.KMAC_STATUS = KmacStatusWSR('KMAC_STATUS', self.Kmac)
         self.KMAC_DIGEST = KmacDigestWSR('KMAC_DIGEST', self.Kmac)
+        self.KMAC_PARTIAL_WRITE = KmacPartialWriteISPR('KMAC_PARTIAL_WRITE', self.Kmac)
+        self.KMAC_MSG = KmacMsgWSR('KMAC_MSG', self.Kmac, self.KMAC_PARTIAL_WRITE)
 
         self._by_idx = {
             0: self.MOD,
@@ -1152,6 +1233,7 @@ class WSRFile:
         self.KMAC_MSG.commit()
         self.KMAC_CFG.commit()
         self.KMAC_DIGEST.commit()
+        self.KMAC_PARTIAL_WRITE.commit()
 
     def abort(self) -> None:
         self.MOD.abort()
@@ -1165,6 +1247,7 @@ class WSRFile:
         self.KMAC_MSG.abort()
         self.KMAC_CFG.abort()
         self.KMAC_DIGEST.abort()
+        self.KMAC_PARTIAL_WRITE.abort()
 
     def changes(self) -> List[Trace]:
         ret: List[Trace] = []
@@ -1173,10 +1256,11 @@ class WSRFile:
         ret += self.ACC.changes()
         ret += self.KeyS0.changes()
         ret += self.KeyS1.changes()
-        # Commented out until we implement the KMAC interface.
-        # ret += self.KMAC_MSG.changes()
-        # ret += self.KMAC_CFG.changes()
-        # ret += self.KMAC_DIGEST.changes()
+        ret += self.KMAC_MSG.changes()
+        ret += self.KMAC_CFG.changes()
+        ret += self.KMAC_STATUS.changes()
+        ret += self.KMAC_DIGEST.changes()
+        ret += self.KMAC_PARTIAL_WRITE.changes()
         return ret
 
     def set_sideload_keys(self,

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -430,7 +430,9 @@ class KmacBlock:
         self._app_intf_fifo_ready = True
         self._app_intf_fifo_ready_next = True
         self._app_intf_fifo_flush = False
+        self._pending_app_intf_last = False
         self._app_intf_last = False
+        self._app_intf_last_latch = False
         self._msg_fifo_flush_ctr = 0
         self._msg_fifo_flush = False
         self._msg_fifo_flushed = False
@@ -446,6 +448,8 @@ class KmacBlock:
         self._new_permutation = False
         self._digest_request_ctr = 0
         self._skip_digest_shift_cycle = False
+        self._kmac_undersized_err = False
+        self._kmac_oversized_err = False
 
     def _reset(self) -> None:
         self._status = self._STATUS_IDLE
@@ -459,15 +463,21 @@ class KmacBlock:
         self._mode = self._MODE_SHA3
         self._msg_fifo = bytes()
         self._app_intf_fifo = bytes()
+        self._app_intf_bytes_sent = 0
+        self._app_intf_sending = False
+        self._app_intf_writing = False
         self._app_intf_ready = False
         self._app_intf_ready_pending_ctr = None
+        self._pending_app_intf_last = False
         self._app_intf_last = False
+        self._app_intf_last_latch = False
         self._app_intf_fifo_ready = True
         self._app_intf_fifo_ready_next = True
         self._app_intf_fifo_flush = False
         self._core_pending_bytes = 0
         self._core_pending_bytes_next = 0
         self._msg_len = 0
+        self._msg_size = 0
         self._pending_process = False
         self._msg_fifo_flush_ctr = 0
         self._msg_fifo_flush = False
@@ -484,6 +494,8 @@ class KmacBlock:
         self._new_permutation = False
         self._digest_request_ctr = 0
         self._skip_digest_shift_cycle = False
+        self._kmac_undersized_err = False
+        self._kmac_oversized_err = False
 
     def set_configuration(self, mode: int, strength: int, msg_len: int) -> None:
         kmac_debug_print(f"\tSetting KMAC config: mode = {mode}, \
@@ -491,7 +503,13 @@ class KmacBlock:
         self._mode = mode
         self._strength = strength
         self._msg_len = msg_len
+        self._msg_size = msg_len
+        self._app_intf_bytes_sent = 0
         self._app_intf_ready_pending_ctr = 0
+        self._app_intf_last_latch = False
+        # Reset error flags
+        self._kmac_undersized_err = False
+        self._kmac_oversized_err = False
         self.start()
 
     def get_error(self) -> int:
@@ -502,6 +520,12 @@ class KmacBlock:
 
     def get_done(self) -> int:
         return int(self.digest_ready())
+
+    def get_undersized(self) -> int:
+        return self._kmac_undersized_err
+
+    def get_oversized(self) -> int:
+        return self._kmac_oversized_err
 
     def message_done(self) -> None:
         '''Indicate that the message input is done.'''
@@ -518,6 +542,21 @@ class KmacBlock:
     def is_squeezing(self) -> bool:
         return self._status == self._STATUS_SQUEEZE
 
+    def digest_req_err(self) -> bool:
+        msg_req_err = (self._msg_len > 0
+                       and len(self._app_intf_fifo) < 8
+                       and self._msg_len != len(self._app_intf_fifo))
+
+        if (
+            not self._app_intf_last_latch
+            and msg_req_err
+            and not self._app_intf_sending
+            and not self._app_intf_writing
+        ):
+            return True
+        else:
+            return False
+
     def digest_ready(self) -> bool:
         kmac_debug_print(f"\tKMAC Digest Ready Req: \
                         autowrite={self._automatically_write_digest} \
@@ -526,6 +565,42 @@ class KmacBlock:
                         read={self._digest_read} ready={self._digest_ready} \
                         read_offset={self._read_offset} \
                         leftover={self._leftover_digest_bytes}")
+
+        # This helper function is executed during a digest wsrr insn
+        # Check if there is an undersized message at this point
+        digest_err = self.digest_req_err()
+
+        # If there is an undersized error we inject a "last" to the message request
+        # to prevent stalling and raise an error flag to the status reg
+        if digest_err and not self._kmac_undersized_err:
+            kmac_debug_print(f"Transaction Error: {digest_err}")
+            msg_fifo_write_ready = self.msg_fifo_bytes_available() >= self._APP_INTF_BYTES_PER_CYCLE
+            if msg_fifo_write_ready and not self._msg_fifo_packer_flushing:
+                nbytes = min(len(self._app_intf_fifo), self._APP_INTF_BYTES_PER_CYCLE)
+                last_byte_valid = self._msg_size % 8
+                kmac_debug_print(f"MSG Size: {self._msg_size}")
+                if (last_byte_valid == 0):
+                    last_byte_valid = 8
+
+                if len(self._app_intf_fifo) < last_byte_valid:
+                    padding_size = last_byte_valid - nbytes
+                    self._app_intf_fifo += bytes(padding_size)
+
+                nbytes = last_byte_valid
+
+                self._msg_fifo += self._app_intf_fifo[:nbytes]
+                self._app_intf_fifo = bytes()
+                self._app_intf_bytes_sent += nbytes
+                # Artificially change the msg size
+                self._msg_size = self._app_intf_bytes_sent
+                self._msg_len = 0
+                self._app_intf_sending = True
+
+                self._kmac_undersized_err = digest_err
+                kmac_debug_print("Inserting Artificial Last MSG")
+                self.message_done()
+                self._app_intf_last = True
+
         if self._automatically_write_digest:
             if self._digest_ready:
                 self._digest_read = True
@@ -729,6 +804,13 @@ class KmacBlock:
                 self._app_intf_ready = True
                 self._app_intf_ready_pending_ctr = None
 
+        kmac_debug_print(f"Last Latch: {self._app_intf_last_latch} \
+                        | Msg Len: {self._msg_len} \
+                        | AppIntf Size: {len(self._app_intf_fifo)} \
+                        | Ready Next: {self._app_intf_fifo_ready_next}")
+
+        kmac_debug_print(f"Pending LAST Status: {self._pending_app_intf_last}")
+
         # MSG FIFO -> KECCAK STATE
         self._core_pending_bytes = self._core_pending_bytes_next
         core_available = self._rate_bytes - self._core_pending_bytes
@@ -739,6 +821,8 @@ class KmacBlock:
         msg_fifo_write_ready = self.msg_fifo_bytes_available() >= self._APP_INTF_BYTES_PER_CYCLE
         if core_available >= 1 and self._core_can_absorb():
             if self._msg_fifo_flush:
+                kmac_debug_print(f"\tIncrementing MSG FIFO FLUSH CTR: \
+                                {self._msg_fifo_flush_ctr} -> {self._msg_fifo_flush_ctr + 1}")
                 self._msg_fifo_flush_ctr += 1
             if len(self._msg_fifo) >= absorb_rate:
                 kmac_debug_print(f"\tMSG FIFO -> STATE: Absorbing 64-bit: \
@@ -786,6 +870,7 @@ class KmacBlock:
 
         # APP FIFO -> MSG FIFO
         self._msg_fifo_flush = self._pending_process
+        kmac_debug_print(f"\tSetting MSG Fifo Flush to Pending Process: {self._msg_fifo_flush}")
         if self._app_intf_last:
             self._app_intf_ready = False
 
@@ -796,6 +881,11 @@ class KmacBlock:
         else:
             self._app_intf_fifo_ready_next = False
 
+        # Set Latch for error detection
+        if (self._app_intf_bytes_sent == self._msg_size):
+            self._app_intf_last_latch = True
+
+        self._app_intf_sending = False
         if msg_fifo_write_ready and not self._msg_fifo_packer_flushing:
             # Pass data from the application interface FIFO to the message FIFO.
             nbytes = min(len(self._app_intf_fifo), self._APP_INTF_BYTES_PER_CYCLE, self._msg_len)
@@ -804,10 +894,11 @@ class KmacBlock:
                             bytes: \
                             {hex(int.from_bytes(self._app_intf_fifo[:nbytes], 'little'))}, \
                             size of contents in MSG FIFO before new data: {len(self._msg_fifo)}")
-            if nbytes >= self._APP_INTF_BYTES_PER_CYCLE:
                 self._msg_fifo += self._app_intf_fifo[:nbytes]
                 self._app_intf_fifo = self._app_intf_fifo[nbytes:]
                 self._msg_len -= nbytes
+                self._app_intf_bytes_sent += nbytes
+                self._app_intf_sending = True
 
             elif (self._app_intf_fifo_flush and nbytes < self._APP_INTF_BYTES_PER_CYCLE):
                 kmac_debug_print(f"\tAPP FIFO -> MSG FIFO: Absorbing {nbytes} \
@@ -817,15 +908,27 @@ class KmacBlock:
                 self._msg_fifo += self._app_intf_fifo[:nbytes]
                 self._app_intf_fifo = self._app_intf_fifo[nbytes:]
                 self._msg_len -= nbytes
+                self._app_intf_bytes_sent += nbytes
                 self._app_intf_fifo_flush = False
+                self._app_intf_sending = True
 
             # Flushing the APP FIFO has an extra clock cycle to read
             elif (
                 self._msg_len < self._APP_INTF_BYTES_PER_CYCLE
                 and self._msg_len != 0
-                and len(self._app_intf_fifo) > 0
+                and len(self._app_intf_fifo) >= self._msg_len
             ):
-                self._app_intf_fifo_flush = True
+                if (len(self._app_intf_fifo) < 8):
+                    # Flushing the APP FIFO has an extra clock cycle to read
+                    self._app_intf_fifo_flush = True
+                else:
+                    # This is an oversized message and has filled the next
+                    # word therefore no etra flush cycle
+                    self._msg_fifo += self._app_intf_fifo[:nbytes]
+                    self._app_intf_fifo = self._app_intf_fifo[8:]
+                    self._msg_len -= nbytes
+                    self._app_intf_bytes_sent += nbytes
+                    self._app_intf_sending = True
 
             kmac_debug_print(f"\tMSG FIFO SIZE: {len(self._msg_fifo)}")
         else:
@@ -893,6 +996,40 @@ class KmacBlock:
                 self._msg_fifo_flush_ctr = 0
                 self._msg_fifo_flushed = False
                 self._msg_fifo_packer_flushed = False
+
+        # The following check determines if there is an oversized message and will flush the
+        # remaining bytes to avoid stalling while setting the error flag high
+        if (
+            self._app_intf_last_latch
+            and self._app_intf_bytes_sent >= self._msg_size
+            and len(self._app_intf_fifo) > 0
+        ):
+            self._pending_app_intf_last = False
+            nbytes = min(len(self._app_intf_fifo), self._APP_INTF_BYTES_PER_CYCLE)
+            self._app_intf_fifo = self._app_intf_fifo[nbytes:]
+            self._kmac_oversized_err = True
+            kmac_debug_print("FLUSHING FIFO WITH OVERSIZED MSG")
+
+            # The fifo will be ready in the next clock cycle if there is 8B or less
+            if len(self._app_intf_fifo) <= self._APP_INTF_BYTES_PER_CYCLE:
+                kmac_debug_print("\tAPP INTF FIFO LESS THAN ONE WORD IN NEXT STEP")
+                self._app_intf_fifo_ready_next = True
+            else:
+                self._app_intf_fifo_ready_next = False
+
+        if self._pending_app_intf_last and len(self._app_intf_fifo) > self._msg_len:
+            self._app_intf_fifo = self._app_intf_fifo[:self._msg_len]
+            self._kmac_oversized_err = True
+            kmac_debug_print("FLUSHING FIFO WITH OVERSIZED MSG")
+
+        if (
+            self._msg_len <= len(self._app_intf_fifo)
+            and self._msg_len <= self._APP_INTF_BYTES_PER_CYCLE
+            and len(self._app_intf_fifo) <= self._APP_INTF_BYTES_PER_CYCLE
+        ):
+            self._pending_app_intf_last = True
+        else:
+            self._pending_app_intf_last = False
 
     def max_read_bytes(self) -> int:
         '''Returns the maximum readable bytes before a `run` command.'''
@@ -996,6 +1133,7 @@ class KmacMsgWSR(WSR):
 
     def step(self) -> None:
         self._kmac.step()
+        self._kmac._app_intf_writing = False
         kmac_debug_print("\tFETCHING STARTING FIFO STATUS")
         self._pending_write_stall_pw = self._pending_write_to_app_intf
         self._start_cycle_fifo_ready = self._kmac.app_intf_fifo_ready()
@@ -1004,10 +1142,19 @@ class KmacMsgWSR(WSR):
             strb_len = self._partial_ispr.read_mask()
             value_bytes = int.to_bytes(self._value, byteorder='little', length=32)[:strb_len]
             kmac_debug_print("\tPending write to App FIFO")
-            if self._kmac.write_to_app_intf_fifo(value_bytes):
+            if (
+                self._kmac._app_intf_last_latch
+                or self._kmac._pending_app_intf_last
+                and not self.pending_write()
+            ):
+                kmac_debug_print("DROPPING WRITE TO FIFO FROM OVERSIZED MSG")
+                self._pending_write_to_app_intf = False
+                self._pending_write_stall_pw = False
+            elif self._kmac.write_to_app_intf_fifo(value_bytes):
                 kmac_debug_print(f"\tKMAC_MSG -> APP FIFO: Writing \
                                  {len(value_bytes)} bytes to App FIFO")
                 self._pending_write_to_app_intf = False
+                self._kmac._app_intf_writing = True
 
     def pending_write(self) -> bool:
         return self._pending_write_stall_pw
@@ -1022,7 +1169,10 @@ class KmacMsgWSR(WSR):
             if self._next_value is not None:
                 kmac_debug_print(f"\tREG -> KMAC_MSG reg: {hex(self._next_value)}")
                 self._value = self._next_value
-                self._pending_write_to_app_intf = True
+                if self._kmac._app_intf_last_latch or self._kmac._pending_app_intf_last:
+                    self._pending_write_to_app_intf = False
+                else:
+                    self._pending_write_to_app_intf = True
                 self._pending_write_stall_pw = True
             else:
                 # Silence F841 warning until we reimplement the KMAC interface.
@@ -1081,7 +1231,9 @@ class KmacStatusWSR(WSR):
         self._kmac = kmac
 
     def read_unsigned(self) -> int:
-        value = self._kmac.get_error() << 2
+        value = self._kmac.get_undersized() << 4
+        value += self._kmac.get_oversized() << 3
+        value += self._kmac.get_error() << 2
         value += self._kmac.get_ready() << 1
         value += self._kmac.get_done()
         return value

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -407,7 +407,8 @@ class KmacBlock:
 
     # After setting the KMAC_CFG register, it takes two cycles until the KMAC_STATUS
     # register changes its value to ready.
-    _APP_INTF_READY_LATENCY = 3
+    # The third cycle holds the CFG word with KMAC now ready, 4th cycle is MSG
+    _APP_INTF_READY_LATENCY = 4
 
     # If a new chunk of the digest is requested for the DIGEST REG, there is a delay of
     # X cycles.
@@ -545,8 +546,7 @@ class KmacBlock:
     def digest_req_err(self) -> bool:
         msg_req_err = (self._msg_len > 0
                        and len(self._app_intf_fifo) < 8
-                       and self._msg_len != len(self._app_intf_fifo))
-
+                       and self._msg_len > len(self._app_intf_fifo))
         if (
             not self._app_intf_last_latch
             and msg_req_err
@@ -886,7 +886,7 @@ class KmacBlock:
             self._app_intf_last_latch = True
 
         self._app_intf_sending = False
-        if msg_fifo_write_ready and not self._msg_fifo_packer_flushing:
+        if msg_fifo_write_ready and not self._msg_fifo_packer_flushing and self._app_intf_ready:
             # Pass data from the application interface FIFO to the message FIFO.
             nbytes = min(len(self._app_intf_fifo), self._APP_INTF_BYTES_PER_CYCLE, self._msg_len)
             if nbytes >= self._APP_INTF_BYTES_PER_CYCLE:
@@ -1059,7 +1059,7 @@ class KmacBlock:
 class KmacPartialWriteISPR(WSR):
     '''Keccak partial write WSR
 
-    This register defines the numbeer of valid bytes in the
+    This register defines the number of valid bytes in the
     KmacMsgWSR register for writing partial words and STRB
     on the KMAC Req AppIntf
     '''
@@ -1075,9 +1075,9 @@ class KmacPartialWriteISPR(WSR):
     def read_mask(self) -> int:
         if self._value is None:
             return 32
-        elif self._value != (1 << self._value.bit_count()) - 1:
+        elif self._value > 32:
             raise ValueError(f'Invalid mask size for KMAC_PARTIAL_WRITE: {self._value:#066x}')
-        return self._value.bit_count()
+        return self._value
 
     def write_unsigned(self, value: int) -> None:
         self._next_value = value
@@ -1144,20 +1144,20 @@ class KmacMsgWSR(WSR):
             kmac_debug_print("\tPending write to App FIFO")
             if (
                 self._kmac._app_intf_last_latch
-                or self._kmac._pending_app_intf_last
-                and not self.pending_write()
+                or (self._kmac._pending_app_intf_last and not self.pending_write())
+                or self._kmac._app_intf_fifo_flush
             ):
                 kmac_debug_print("DROPPING WRITE TO FIFO FROM OVERSIZED MSG")
                 self._pending_write_to_app_intf = False
                 self._pending_write_stall_pw = False
-            elif self._kmac.write_to_app_intf_fifo(value_bytes):
+            elif not self._kmac._app_intf_last and self._kmac.write_to_app_intf_fifo(value_bytes):
                 kmac_debug_print(f"\tKMAC_MSG -> APP FIFO: Writing \
                                  {len(value_bytes)} bytes to App FIFO")
                 self._pending_write_to_app_intf = False
                 self._kmac._app_intf_writing = True
 
     def pending_write(self) -> bool:
-        return self._pending_write_stall_pw
+        return self._pending_write_stall_pw or self._kmac._app_intf_fifo_flush
 
     def request_write(self) -> bool:
         return self._start_cycle_fifo_ready
@@ -1188,10 +1188,11 @@ class KmacMsgWSR(WSR):
 class KmacCfgWSR(WSR):
     '''Keccak config WSR: used to set SHA3 mode and Keccak Strength
     '''
-    def __init__(self, name: str, kmac: KmacBlock):
+    def __init__(self, name: str, kmac: KmacBlock, partial_ispr: KmacPartialWriteISPR):
         super().__init__(name)
         self._value = 0
         self._kmac = kmac
+        self._partial_ispr = partial_ispr
 
     def read_unsigned(self) -> int:
         return self._value
@@ -1203,6 +1204,8 @@ class KmacCfgWSR(WSR):
     def commit(self) -> None:
         if self._pending_write:
             self._value = self._next_value
+            # We reset the PW value each config write to reduce uneccesary writes
+            self._partial_ispr._value = 32
             kmac_debug_print(f"\tREG -> KMAC_MSG reg: {hex(self._next_value)}")
             if self._value == (1 << 31):
                 # config value to release KMAC app intf
@@ -1318,10 +1321,10 @@ class WSRFile:
         self.KeyS0H = KeyWSR('KeyS0H', 256, self.KeyS0)
         self.KeyS1L = KeyWSR('KeyS1L', 0, self.KeyS1)
         self.KeyS1H = KeyWSR('KeyS1H', 256, self.KeyS1)
-        self.KMAC_CFG = KmacCfgWSR('KMAC_CFG', self.Kmac)
         self.KMAC_STATUS = KmacStatusWSR('KMAC_STATUS', self.Kmac)
         self.KMAC_DIGEST = KmacDigestWSR('KMAC_DIGEST', self.Kmac)
         self.KMAC_PARTIAL_WRITE = KmacPartialWriteISPR('KMAC_PARTIAL_WRITE', self.Kmac)
+        self.KMAC_CFG = KmacCfgWSR('KMAC_CFG', self.Kmac, self.KMAC_PARTIAL_WRITE)
         self.KMAC_MSG = KmacMsgWSR('KMAC_MSG', self.Kmac, self.KMAC_PARTIAL_WRITE)
 
         self._by_idx = {

--- a/hw/ip/otbn/dv/smoke/smoke_test.s
+++ b/hw/ip/otbn/dv/smoke/smoke_test.s
@@ -1,4 +1,5 @@
 /* Copyright lowRISC contributors (OpenTitan project). */
+/* Copyright zeroRISC Inc. */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
@@ -116,6 +117,28 @@ csrrw x0, mod0, x23
 
 # x22 = 0x89c9b54f
 csrrs x23, mod5, x0
+
+bn.wsrr w1, 0x0 /* MOD 82a 4ea*/
+li x23, 0xdeadbeef
+csrrw x0, mod7, x23
+bn.wsrr w2, 0x0 /* MOD 82a 4ea*/
+li x23, 0x000004ea
+csrrw x0, kmac_cfg, x23
+li x23, 0x03ffffff
+csrrw x0, kmac_partial_write, x23
+bn.wsrw 0x9, w1 /* MSG */
+li x23, 0x00001fff
+csrrw x0, kmac_partial_write, x23
+bn.wsrw 0x9, w1 /* MSG */
+bn.wsrr w1, 0xa /* DIGEST */
+bn.wsrr w1, 0xa /* DIGEST */
+bn.wsrr w1, 0xa /* DIGEST */
+bn.wsrr w1, 0xa /* DIGEST */
+bn.wsrr w1, 0xa /* DIGEST */
+li x23, 0x800004ea /* STOP CFG 0x8000040a */
+csrrw x0, kmac_cfg, x23
+
+li x23, 0x53769ada
 
 # Note that some instructions used the fixed inputs (from w1 and w2) others use
 # results from previous instructions. When debugging an failure it is recommended

--- a/hw/ip/otbn/dv/smoke/smoke_test.s
+++ b/hw/ip/otbn/dv/smoke/smoke_test.s
@@ -119,15 +119,12 @@ csrrw x0, mod0, x23
 csrrs x23, mod5, x0
 
 bn.wsrr w1, 0x0 /* MOD 82a 4ea*/
-li x23, 0xdeadbeef
-csrrw x0, mod7, x23
-bn.wsrr w2, 0x0 /* MOD 82a 4ea*/
 li x23, 0x000004ea
 csrrw x0, kmac_cfg, x23
-li x23, 0x03ffffff
+li x23, 0x0000001a
 csrrw x0, kmac_partial_write, x23
 bn.wsrw 0x9, w1 /* MSG */
-li x23, 0x00001fff
+li x23, 0x0000000d
 csrrw x0, kmac_partial_write, x23
 bn.wsrw 0x9, w1 /* MSG */
 bn.wsrr w1, 0xa /* DIGEST */

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -262,6 +263,10 @@ interface otbn_trace_if
                                             u_otbn_alu_bignum.mod_intg_q[i_word*39+:32];
     assign ispr_read_data[IsprMod][i_word*32+:32] = u_otbn_alu_bignum.mod_intg_q[i_word*39+:32];
     assign ispr_write_data[IsprAcc][i_word*32+:32] = u_otbn_mac_bignum.acc_intg_d[i_word*39+:32];
+    assign ispr_write_data[IsprKmacMsg][i_word*32+:32] =
+      u_otbn_alu_bignum.kmac_msg_wr_en[i_word] ? u_otbn_alu_bignum.kmac_msg_intg_d[i_word*39+:32] :
+                                                 u_otbn_alu_bignum.kmac_msg_intg_q[i_word*39+:32];
+    assign ispr_read_data[IsprKmacMsg][i_word*32+:32] = u_otbn_alu_bignum.kmac_msg_intg_q[i_word*39+:32];
   end
 
   assign ispr_read[IsprMod] =
@@ -269,6 +274,29 @@ interface otbn_trace_if
     (insn_fetch_resp_valid &
      (alu_bignum_operation.op inside {AluOpBignumAddm, AluOpBignumSubm}));
 
+  // KMAC MSG
+  assign ispr_read[IsprKmacMsg] =
+    (any_ispr_read & (ispr_addr == IsprKmacMsg));
+
+  assign ispr_write[IsprKmacMsg] = u_otbn_alu_bignum.kmac_msg_wr_en & ~ispr_init;
+
+  // KMAC CFG
+  assign ispr_read[IsprKmacCfg] =
+    (any_ispr_read & (ispr_addr == IsprKmacCfg));
+
+  assign ispr_read_data[IsprKmacCfg]  = {224'b0, u_otbn_alu_bignum.kmac_cfg_intg_q[31:0]};
+  assign ispr_write[IsprKmacCfg]      = u_otbn_alu_bignum.kmac_cfg_wr_en & ~ispr_init;
+  assign ispr_write_data[IsprKmacCfg] = {224'b0, u_otbn_alu_bignum.kmac_cfg_intg_d[31:0]};
+
+  // KMAC PARTIAL WRITE
+  assign ispr_read[IsprKmacPartialW] =
+    (any_ispr_read & (ispr_addr == IsprKmacPartialW));
+
+  assign ispr_read_data[IsprKmacPartialW]   = {224'b0, u_otbn_alu_bignum.kmac_pw_intg_q[31:0]};
+  assign ispr_write[IsprKmacPartialW]       = u_otbn_alu_bignum.kmac_pw_wr_en & ~ispr_init;
+  assign ispr_write_data[IsprKmacPartialW]  = {224'b0, u_otbn_alu_bignum.kmac_pw_intg_d[31:0]};
+
+  // ACC
   assign ispr_write[IsprAcc] = u_otbn_mac_bignum.acc_en & ~ispr_init;
 
   assign ispr_read[IsprAcc] = (any_ispr_read & (ispr_addr == IsprAcc)) | mac_bignum_en;

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -90,6 +91,9 @@ module otbn_tracer (
       IsprRnd: return "RND";
       IsprFlags: return "FLAGS";
       IsprUrnd: return "URND";
+      IsprKmacMsg: return "KMAC_MSG";
+      IsprKmacCfg: return "KMAC_CFG";
+      IsprKmacPartialW: return "KMAC_PARTIAL_WRITE";
       default: return "UNKNOWN_ISPR";
     endcase
   endfunction

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -133,7 +133,10 @@ module tb;
     .otbn_otp_key_o(otp_key_req),
     .otbn_otp_key_i(otp_key_rsp),
 
-    .keymgr_key_i(sideload_key)
+    .keymgr_key_i(sideload_key),
+
+    .kmac_data_o(app_req),
+    .kmac_data_i(app_rsp)
   );
 
   bind dut.u_otbn_core otbn_trace_if #(

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -1,5 +1,6 @@
 CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:ip:otbn:0.1"
@@ -20,6 +21,7 @@ filesets:
       - lowrisc:prim:blanker
       - lowrisc:ip:keymgr_pkg
       - lowrisc:ip:edn_pkg
+      - lowrisc:ip:kmac_pkg
       - lowrisc:ip:otbn_pkg
       - lowrisc:prim:onehot_check
     files:

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -1,4 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192)
+// Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -74,7 +77,11 @@ module otbn
   output otp_ctrl_pkg::otbn_otp_key_req_t otbn_otp_key_o,
   input  otp_ctrl_pkg::otbn_otp_key_rsp_t otbn_otp_key_i,
 
-  input keymgr_pkg::otbn_key_req_t keymgr_key_i
+  input keymgr_pkg::otbn_key_req_t keymgr_key_i,
+
+  // KMAC interface
+  output kmac_pkg::app_req_t      kmac_data_o,
+  input  kmac_pkg::app_rsp_t      kmac_data_i
 );
 
   import prim_mubi_pkg::*;
@@ -142,6 +149,12 @@ module otbn
 
   tlul_pkg::tl_h2d_t tl_win_h2d[2];
   tlul_pkg::tl_d2h_t tl_win_d2h[2];
+
+  kmac_pkg::app_req_t kmac_req;
+  kmac_pkg::app_rsp_t kmac_rsp;
+
+  assign kmac_data_o = kmac_req;
+  assign kmac_rsp    = kmac_data_i;
 
   // The clock can be gated and some registers can be updated as long as OTBN isn't currently
   // running. Other registers can only be updated when OTBN is in the Idle state (which also implies
@@ -1157,7 +1170,10 @@ module otbn
     .software_errs_fatal_i       (software_errs_fatal_q),
 
     .sideload_key_shares_i       (keymgr_key_i.key),
-    .sideload_key_shares_valid_i ({2{keymgr_key_i.valid}})
+    .sideload_key_shares_valid_i ({2{keymgr_key_i.valid}}),
+
+    .kmac_app_req_o (kmac_req),
+    .kmac_app_rsp_i (kmac_rsp)
   );
 
   always_ff @(posedge clk_i or negedge rst_n) begin

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -1,4 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192)
+// Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -101,6 +104,7 @@ module otbn_alu_bignum
   output logic                        reg_intg_violation_err_o,
 
   input  logic                        sec_wipe_mod_urnd_i,
+  input  logic                        sec_wipe_kmac_regs_urnd_i,
   input  logic                        sec_wipe_running_i,
   output logic                        sec_wipe_err_o,
 
@@ -113,7 +117,14 @@ module otbn_alu_bignum
   input  logic [1:0][SideloadKeyWidth-1:0] sideload_key_shares_i,
 
   output logic alu_predec_error_o,
-  output logic ispr_predec_error_o
+  output logic ispr_predec_error_o,
+
+  output logic kmac_msg_write_ready_o,
+  output logic kmac_msg_pending_write_o,
+  output logic kmac_digest_valid_o,
+
+  output kmac_pkg::app_req_t          kmac_app_req_o,
+  input  kmac_pkg::app_rsp_t          kmac_app_rsp_i
 );
 
   logic [WLEN+1:0] adder_y_res;
@@ -405,6 +416,487 @@ module otbn_alu_bignum
                                sec_wipe_mod_urnd_i;
   end
 
+  //////////
+  // KMAC //
+  //////////
+
+  // CFG
+  logic [BaseIntgWidth-1:0] kmac_cfg_intg_q;
+  logic [31:0]              kmac_cfg_no_intg_d;
+  logic [BaseIntgWidth-1:0] kmac_cfg_intg_d;
+  logic [BaseIntgWidth-1:0] kmac_cfg_intg_calc;
+  logic                     kmac_cfg_ispr_wr_en;
+  logic                     kmac_cfg_wr_en;
+  logic [1:0]               kmac_cfg_intg_err;
+
+  logic [ExtWLEN-1:0] ispr_kmac_cfg_bignum_wdata_intg_blanked;
+
+  prim_secded_inv_39_32_enc u_kmac_cfg_secded_enc (
+    .data_i (kmac_cfg_no_intg_d),
+    .data_o (kmac_cfg_intg_calc)
+  );
+  prim_secded_inv_39_32_dec u_kmac_cfg_secded_dec (
+    .data_i     (kmac_cfg_intg_q),
+    .data_o     (/* unused because we abort on any integrity error */),
+    .syndrome_o (/* unused */),
+    .err_o      (kmac_cfg_intg_err)
+  );
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_cfg_intg_q <= '0;
+    end else if (kmac_cfg_wr_en) begin
+      kmac_cfg_intg_q <= kmac_cfg_intg_d;
+    end
+  end
+
+  always_comb begin
+    unique case (1'b1)
+      ispr_init_i: begin
+        kmac_cfg_no_intg_d  = 32'b0;
+        kmac_cfg_intg_d     = kmac_cfg_intg_calc;
+      end
+      ispr_base_wr_en_i[0]: begin // Index 0 because only first 32-bit word contains cfg
+        kmac_cfg_no_intg_d  = ispr_base_wdata_i;
+        kmac_cfg_intg_d     = kmac_cfg_intg_calc;
+      end
+      default: begin
+        kmac_cfg_no_intg_d  = 32'b0;
+        kmac_cfg_intg_d     = ispr_kmac_cfg_bignum_wdata_intg_blanked[38:0];
+      end
+    endcase
+  end
+
+  `ASSERT(KmacCfgWrSelOneHot, $onehot0({ispr_init_i, ispr_base_wr_en_i[0]}))
+
+  // Index 0 because only first 32-bit word contains cfg
+  assign kmac_cfg_ispr_wr_en = (ispr_addr_i == IsprKmacCfg) &
+                               (ispr_base_wr_en_i[0] | ispr_bignum_wr_en_i) &
+                               ispr_wr_commit_i;
+
+  assign kmac_cfg_wr_en = (ispr_init_i | kmac_cfg_ispr_wr_en) & !kmac_app_rsp_i.error;
+
+  prim_blanker #(.Width(ExtWLEN)) u_ispr_kmac_cfg_bignum_wdata_blanker (
+    .in_i (ispr_bignum_wdata_intg_i),
+    .en_i (ispr_predec_bignum_i.ispr_wr_en[IsprKmacCfg]),
+    .out_o(ispr_kmac_cfg_bignum_wdata_intg_blanked)
+  );
+
+  // PARTIAL WRITE
+  logic [BaseIntgWidth-1:0] kmac_pw_intg_q;
+  logic [31:0]              kmac_pw_no_intg_d;
+  logic [BaseIntgWidth-1:0] kmac_pw_intg_d;
+  logic [BaseIntgWidth-1:0] kmac_pw_intg_calc;
+  logic                     kmac_pw_ispr_wr_en;
+  logic                     kmac_pw_wr_en;
+  logic [1:0]               kmac_pw_intg_err;
+  logic                     kmac_msg_valid_q;
+
+  logic [ExtWLEN-1:0] ispr_kmac_pw_bignum_wdata_intg_blanked;
+
+  prim_secded_inv_39_32_enc u_kmac_pw_secded_enc (
+    .data_i (kmac_pw_no_intg_d),
+    .data_o (kmac_pw_intg_calc)
+  );
+  prim_secded_inv_39_32_dec u_kmac_pw_secded_dec (
+    .data_i     (kmac_pw_intg_q),
+    .data_o     (/* unused because we abort on any integrity error */),
+    .syndrome_o (/* unused */),
+    .err_o      (kmac_pw_intg_err)
+  );
+
+  always_ff @(posedge clk_i) begin
+    if (kmac_pw_wr_en) begin
+      kmac_pw_intg_q  <= kmac_pw_intg_d;
+    end
+  end
+
+  always_comb begin
+    unique case(1'b1)
+      ispr_init_i: begin
+        kmac_pw_no_intg_d = 32'b0;
+        kmac_pw_intg_d    = kmac_pw_intg_calc;
+      end
+      ispr_base_wr_en_i[0]: begin
+        kmac_pw_no_intg_d = ispr_base_wdata_i;
+        kmac_pw_intg_d    = kmac_pw_intg_calc;
+      end
+      default: begin
+        kmac_pw_no_intg_d = 32'b0;
+        kmac_pw_intg_d    = ispr_kmac_pw_bignum_wdata_intg_blanked[38:0];
+      end
+    endcase
+  end
+
+  `ASSERT(KmacPWWrSelOneHot, $onehot0({ispr_init_i, ispr_base_wr_en_i[0]}))
+
+  // Index 0 because only first 32-bit word contains cfg
+  assign kmac_pw_ispr_wr_en = (ispr_addr_i == IsprKmacPartialW) &
+                              (ispr_base_wr_en_i[0] | ispr_bignum_wr_en_i) &
+                              ispr_wr_commit_i;
+
+  assign kmac_pw_wr_en = (ispr_init_i | kmac_pw_ispr_wr_en) & ~kmac_msg_valid_q;
+
+  prim_blanker #(.Width(ExtWLEN)) u_ispr_kmac_pw_bignum_wdata_blanker (
+    .in_i (ispr_bignum_wdata_intg_i),
+    .en_i (ispr_predec_bignum_i.ispr_wr_en[IsprKmacPartialW]),
+    .out_o(ispr_kmac_pw_bignum_wdata_intg_blanked)
+  );
+
+  // MSG
+  logic [ExtWLEN-1:0]             kmac_msg_intg_q;
+  logic [ExtWLEN-1:0]             kmac_msg_intg_d;
+  logic [BaseWordsPerWLEN-1:0]    kmac_msg_ispr_wr_en;
+  logic [BaseWordsPerWLEN-1:0]    kmac_msg_wr_en;
+
+  logic [WLEN-1:0]                kmac_msg_no_intg_d;
+  logic [WLEN-1:0]                kmac_msg_no_intg_q;
+  logic [ExtWLEN-1:0]             kmac_msg_intg_calc;
+  logic [2*BaseWordsPerWLEN-1:0]  kmac_msg_intg_err;
+
+  logic                           kmac_msg_wr_stall;
+  logic                           kmac_msg_raw;
+
+  logic [ExtWLEN-1:0] ispr_kmac_msg_bignum_wdata_intg_blanked;
+
+  prim_blanker #(.Width(ExtWLEN)) u_ispr_kmac_msg_bignum_wdata_blanker (
+    .in_i (ispr_bignum_wdata_intg_i),
+    .en_i (ispr_predec_bignum_i.ispr_wr_en[IsprKmacMsg]),
+    .out_o(ispr_kmac_msg_bignum_wdata_intg_blanked)
+  );
+
+  for (genvar i_word = 0; i_word < BaseWordsPerWLEN; i_word++) begin : g_kmac_msg_words
+    prim_secded_inv_39_32_enc i_kmac_msg_secded_enc (
+      .data_i (kmac_msg_no_intg_d[i_word*32+:32]),
+      .data_o (kmac_msg_intg_calc[i_word*39+:39])
+    );
+    prim_secded_inv_39_32_dec i_kmac_msg_secded_dec (
+      .data_i     (kmac_msg_intg_q[i_word*39+:39]),
+      .data_o     (/* unused because we abort on any integrity error */),
+      .syndrome_o (/* unused */),
+      .err_o      (kmac_msg_intg_err[i_word*2+:2])
+    );
+
+    always_ff @(posedge clk_i) begin
+      if (kmac_msg_wr_en[i_word]) begin
+        kmac_msg_intg_q[i_word*39+:39] <= kmac_msg_intg_d[i_word*39+:39];
+      end
+    end
+    assign kmac_msg_no_intg_q[i_word*32+:32] = kmac_msg_intg_q[i_word*39+:32];
+
+    always_comb begin
+      kmac_msg_no_intg_d[i_word*32+:32] = '0;
+      kmac_msg_intg_d[i_word*39+:39] = '0;
+      if (sec_wipe_kmac_regs_urnd_i) begin
+        // Non-encoded inputs have to be encoded before writing to the register.
+        kmac_msg_no_intg_d[i_word*32+:32] = urnd_data_i[i_word*32+:32];
+        kmac_msg_intg_d[i_word*39+:39] = kmac_msg_intg_calc[i_word*39+:39];
+      end else begin
+        // Pre-encoded inputs can directly be written to the register.
+        kmac_msg_intg_d[i_word*39+:39] = ispr_kmac_msg_bignum_wdata_intg_blanked[i_word*39+:39];
+      end
+    end
+
+    `ASSERT(KmacMsgWrSelOneHot, $onehot0({ispr_init_i, ispr_base_wr_en_i[i_word]}))
+
+    assign kmac_msg_ispr_wr_en[i_word] = (ispr_addr_i == IsprKmacMsg) &
+                                         (ispr_base_wr_en_i[i_word] | ispr_bignum_wr_en_i) &
+                                         ispr_wr_commit_i;
+
+    assign kmac_msg_wr_en[i_word] = (ispr_init_i |
+                                    (kmac_msg_ispr_wr_en[i_word] & kmac_msg_write_ready_o) |
+                                    sec_wipe_kmac_regs_urnd_i) & ~kmac_msg_wr_stall;
+  end
+
+  assign kmac_msg_raw = (ispr_addr_i == IsprKmacMsg) & ispr_wr_commit_i;
+
+  // STATUS
+  logic [BaseIntgWidth-1:0] kmac_status_intg_q;
+  logic [BaseIntgWidth-1:0] kmac_status_intg_d;
+  logic [31:0]              kmac_status_no_intg_d;
+  logic [1:0]               kmac_status_intg_err;
+
+  logic kmac_new_cfg_q;
+
+  assign kmac_status_no_intg_d = kmac_new_cfg_q ? 32'b0 : {29'b0, kmac_app_rsp_i.error, kmac_app_rsp_i.ready, kmac_app_rsp_i.done};
+
+  prim_secded_inv_39_32_enc u_kmac_status_secded_enc (
+    .data_i (kmac_status_no_intg_d),
+    .data_o (kmac_status_intg_d)
+  );
+  prim_secded_inv_39_32_dec u_kmac_status_secded_dec (
+    .data_i     (kmac_status_intg_q),
+    .data_o     (/* unused because we abort on any integrity error */),
+    .syndrome_o (/* unused */),
+    .err_o      (kmac_status_intg_err)
+  );
+
+  always_ff @(posedge clk_i) begin
+    kmac_status_intg_q <= kmac_status_intg_d;
+  end
+
+  // DIGEST
+  logic [kmac_pkg::AppDigestW-1:0]      unmasked_digest_share;
+  logic [DigestRegLen-1:0]              kmac_digest_no_intg_d;
+  logic [ExtDigestLen-1:0]              kmac_digest_intg_q;
+  logic [ExtDigestLen-1:0]              kmac_digest_intg_d;
+  logic [BaseWordsPerDigestLen-1:0]     kmac_digest_wr_en;
+  logic [2*BaseWordsPerDigestLen-1:0]   kmac_digest_intg_err;
+  logic                                 kmac_digest_rd_next;
+  logic                                 kmac_digest_valid_q;
+  logic                                 kmac_digest_rd;
+
+  assign kmac_digest_valid_o = kmac_digest_valid_q & !kmac_digest_rd;
+  assign kmac_digest_rd_next = kmac_digest_rd && ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest];
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_digest_rd <= 1'b0;
+    end else if (kmac_digest_rd_next || kmac_new_cfg_q) begin
+      kmac_digest_rd <= 1'b0;
+    end else if (ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest] && kmac_digest_valid_q) begin
+      kmac_digest_rd <= 1'b1;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_digest_valid_q <= 1'b0;
+    end else if (kmac_digest_rd_next || kmac_new_cfg_q) begin
+      kmac_digest_valid_q <= 1'b0;
+    end else if (kmac_app_rsp_i.done) begin
+      kmac_digest_valid_q <= 1'b1;
+    end
+  end
+
+  for (genvar i_word = 0; i_word < BaseWordsPerDigestLen; i_word++) begin : g_kmac_digest_words
+    prim_secded_inv_39_32_enc i_kmac_digest_secded_enc (
+      .data_i (kmac_digest_no_intg_d[i_word*32+:32]),
+      .data_o (kmac_digest_intg_d[i_word*39+:39])
+    );
+    prim_secded_inv_39_32_dec i_kmac_digest_secded_dec (
+      .data_i     (kmac_digest_intg_q[i_word*39+:39]),
+      .data_o     (/* unused because we abort on any integrity error */),
+      .syndrome_o (/* unused */),
+      .err_o      (kmac_digest_intg_err[i_word*2+:2])
+    );
+
+    always_ff @(posedge clk_i) begin
+      if (kmac_digest_wr_en[i_word]) begin
+        kmac_digest_intg_q[i_word*39+:39] <= kmac_digest_intg_d[i_word*39+:39];
+      end
+    end
+
+    assign kmac_digest_no_intg_d[i_word*32+:32] = sec_wipe_kmac_regs_urnd_i ?
+                                                    urnd_data_i[(i_word % BaseWordsPerDigestLen)*32+:32] :
+                                                    unmasked_digest_share[i_word*32+:32];
+
+    assign kmac_digest_wr_en[i_word] = kmac_app_rsp_i.done | sec_wipe_kmac_regs_urnd_i;
+  end
+
+  // Digest shares are xor'ed to get the unmasked share value
+  // If KMAC is operating in unmasked mode then share1 is '0 and xor remains the unmasked val
+  assign unmasked_digest_share = kmac_app_rsp_i.digest_share0 ^ kmac_app_rsp_i.digest_share1;
+
+  // MSG INTERFACE
+  sha3_pkg::sha3_mode_e           kmac_cfg_sha3_mode;
+  sha3_pkg::keccak_strength_e     kmac_cfg_keccak_strength;
+  logic [10:0]                    kmac_cfg_unused_msg_len;
+  logic [14:0]                    kmac_cfg_msg_len;
+  logic [11:0]                    kmac_cfg_msg_len_words;
+  logic [2:0]                     kmac_cfg_msg_len_bytes;
+  logic [11:0]                    kmac_msg_ctr;
+
+  logic                           kmac_msg_clr;
+  logic                           kmac_msg_fifo_wvalid;
+  logic                           kmac_msg_fifo_wready;
+  logic [WLEN-1:0]                kmac_msg_fifo_wdata;
+  logic [WLEN-1:0]                kmac_msg_fifo_wdata_mask;
+  logic                           kmac_msg_fifo_rvalid;
+  logic                           kmac_msg_fifo_rready;
+  logic [kmac_pkg::MsgWidth-1:0]  kmac_msg_fifo_rdata;
+  logic [kmac_pkg::MsgWidth-1:0]  kmac_msg_fifo_rdata_mask;
+  logic                           kmac_msg_fifo_flush;
+  logic [kmac_pkg::MsgStrbW-1:0]  kmac_msg_strb;
+  logic                           kmac_last_msg_all_bytes_valid;
+  logic [kmac_pkg::MsgStrbW-1:0]  kmac_last_msg_strb;
+
+  logic       packer_ctr_last;
+  logic [7:0] packer_rdata_mask;
+  logic [3:0] packer_rdata_mask_cnt;
+
+  logic kmac_msg_active_q;
+  logic kmac_cfg_active_q;
+  logic kmac_write_cfg_to_app;
+  logic kmac_msg_ctr_err;
+  logic kmac_msg_last;
+  logic kmac_idle_q;
+  logic kmac_cfg_done;
+  logic kmac_app_cfg_sent;
+  logic kmac_msg_fifo_pending;
+
+  assign kmac_cfg_sha3_mode       = sha3_pkg::sha3_mode_e'(kmac_cfg_intg_q[1:0]);
+  assign kmac_cfg_keccak_strength = sha3_pkg::keccak_strength_e'(kmac_cfg_intg_q[4:2]);
+  assign kmac_cfg_done            = kmac_cfg_intg_q[31];
+  assign kmac_cfg_msg_len         = kmac_cfg_intg_q[19:5];
+  assign kmac_cfg_msg_len_words   = kmac_cfg_msg_len[14:3];
+  assign kmac_cfg_msg_len_bytes   = kmac_cfg_msg_len[2:0];
+  assign kmac_msg_clr             = kmac_app_rsp_i.error | sec_wipe_kmac_regs_urnd_i | kmac_msg_ctr_err;
+
+  assign kmac_last_msg_all_bytes_valid = &(~kmac_cfg_msg_len_bytes);
+  for (genvar i_bit = 1; i_bit < kmac_pkg::MsgStrbW+1; i_bit++) begin
+    assign kmac_last_msg_strb[i_bit-1] = kmac_last_msg_all_bytes_valid ? 1'b1 :
+                                            (i_bit <= kmac_cfg_msg_len_bytes) ? 1'b1 : 1'b0;
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_new_cfg_q <= 1'b0;
+    end else if (kmac_cfg_wr_en & ~sec_wipe_kmac_regs_urnd_i & ~ispr_init_i) begin
+      kmac_new_cfg_q <= 1'b1;
+    end else begin
+      kmac_new_cfg_q <= 1'b0;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_msg_active_q <= 1'b0;
+      kmac_cfg_active_q <= 1'b0;
+    end else if (kmac_new_cfg_q) begin
+      kmac_msg_active_q <= 1'b0;
+      kmac_cfg_active_q <= 1'b1;
+    end else if (kmac_msg_clr || kmac_idle_q) begin
+      kmac_msg_active_q <= 1'b0;
+      kmac_cfg_active_q <= 1'b0;
+    end else if (kmac_msg_fifo_wready) begin //kmac_app_cfg_sent
+      kmac_msg_active_q <= kmac_cfg_active_q;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_msg_valid_q <= 1'b0;
+    end else if (|(kmac_msg_wr_en) & ~sec_wipe_kmac_regs_urnd_i & ~ispr_init_i) begin
+      kmac_msg_valid_q <= 1'b1;
+    end else if (kmac_msg_fifo_wready) begin
+      kmac_msg_valid_q <= 1'b0;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_idle_q <= 1'b1;
+    end else if (kmac_cfg_done) begin
+      kmac_idle_q <= 1'b1;
+    end else begin
+      kmac_idle_q <= 1'b0;
+    end
+  end
+
+  assign kmac_msg_wr_stall = (kmac_msg_raw & (~kmac_msg_fifo_wready));
+
+  assign kmac_write_cfg_to_app = kmac_cfg_active_q && (~kmac_msg_active_q | ~kmac_app_cfg_sent) && ~kmac_idle_q;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_app_cfg_sent <= 1'b0;
+    end else if (kmac_cfg_active_q) begin
+      if (kmac_app_rsp_i.ready) begin
+        kmac_app_cfg_sent <= 1'b1;
+      end
+    end else begin
+      kmac_app_cfg_sent <= 1'b0;
+    end
+  end
+
+  always_comb begin
+    kmac_msg_fifo_wdata_mask = '0;
+    for (int i = 0; i < 32; i++) begin
+      if (kmac_pw_intg_q[i])
+        kmac_msg_fifo_wdata_mask[i*8 +: 8] = 8'hFF;
+    end
+  end
+
+  always_comb begin
+    for (int i = 0; i < kmac_pkg::MsgStrbW; i++) begin
+      kmac_msg_strb[i] = |kmac_msg_fifo_rdata_mask[i*8 +: 8];
+    end
+  end
+
+  always_comb begin
+    for (int i = 0; i < kmac_pkg::MsgStrbW; i++) begin
+      // collapse each 8-bit chunk into one strb bit
+      packer_rdata_mask[i] = |kmac_msg_fifo_rdata_mask[i*8 +: 8];
+    end
+    packer_rdata_mask_cnt = $countones(packer_rdata_mask);
+  end
+
+  assign packer_ctr_last = (kmac_cfg_msg_len_bytes == packer_rdata_mask_cnt) ? 1'b1 : 1'b0;
+
+  assign kmac_msg_fifo_flush = (kmac_msg_last && (kmac_cfg_msg_len_bytes != 3'h0));
+
+  prim_packer #(
+    .InW  (WLEN),
+    .OutW (kmac_pkg::MsgWidth)
+  ) u_kmac_msg_fifo (
+    .clk_i,
+    .rst_ni,
+
+    .valid_i      (kmac_msg_fifo_wvalid),
+    .data_i       (kmac_msg_fifo_wdata),
+    .mask_i       (kmac_msg_fifo_wdata_mask),
+    .ready_o      (kmac_msg_fifo_wready),
+
+    .valid_o      (kmac_msg_fifo_rvalid),
+    .data_o       (kmac_msg_fifo_rdata),
+    .mask_o       (kmac_msg_fifo_rdata_mask),
+    .ready_i      (kmac_msg_fifo_rready),
+
+    .flush_i      (kmac_msg_clr || kmac_new_cfg_q || kmac_msg_fifo_flush),
+    .flush_done_o (),
+
+    .err_o        ()
+  );
+
+  prim_count #(
+    .Width (12),
+    .EnableAlertTriggerSVA('0)
+  ) u_kmac_msg_ctr (
+    .clk_i,
+    .rst_ni,
+
+    .clr_i              (kmac_msg_clr || kmac_new_cfg_q),
+    .set_i              (1'b0),
+    .set_cnt_i          ({(12){1'b0}}),
+    .incr_en_i          (kmac_msg_fifo_rvalid & kmac_app_rsp_i.ready & kmac_msg_fifo_rready),
+    .decr_en_i          (1'b0),
+    .step_i             ({{(11){1'b0}}, {1'b1}}),
+    .commit_i           (1'b1),
+    .cnt_o              (kmac_msg_ctr),
+    .cnt_after_commit_o (/* unused */),
+    .err_o              (kmac_msg_ctr_err)
+  );
+
+  // fifo write iface
+  assign kmac_msg_fifo_wdata      = kmac_msg_no_intg_q;
+  assign kmac_msg_fifo_wvalid     = kmac_msg_valid_q & kmac_msg_fifo_wready;
+  assign kmac_msg_write_ready_o   = kmac_msg_fifo_wready;
+  assign kmac_msg_pending_write_o = kmac_msg_valid_q;
+
+  // fifo read iface
+  assign kmac_msg_last = (kmac_cfg_msg_len_bytes == 3'h0) ? (kmac_msg_ctr >= kmac_cfg_msg_len_words - 1) : ((kmac_msg_ctr >= kmac_cfg_msg_len_words) && packer_ctr_last);
+  assign kmac_msg_fifo_rready = kmac_app_rsp_i.ready & ~kmac_write_cfg_to_app; //kmac_app_cfg_sent
+  assign kmac_app_req_o.valid = (kmac_write_cfg_to_app) ? 1'b1 : kmac_msg_fifo_rvalid & ~kmac_new_cfg_q; //kmac_app_cfg_sent
+  assign kmac_app_req_o.data  = kmac_write_cfg_to_app ?
+                                  {59'b0, kmac_cfg_keccak_strength, kmac_cfg_sha3_mode} :
+                                  kmac_msg_fifo_rdata;
+  assign kmac_app_req_o.strb  = kmac_write_cfg_to_app ?
+                                  8'h01 : kmac_app_req_o.last ? kmac_msg_strb : {(kmac_pkg::MsgStrbW){1'b1}};
+  assign kmac_app_req_o.last  = kmac_msg_fifo_rvalid & kmac_msg_last;
+  assign kmac_app_req_o.next  = kmac_digest_rd & ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest];
+  assign kmac_app_req_o.hold  = kmac_cfg_active_q & ~kmac_new_cfg_q & ~kmac_cfg_done;
+
   /////////
   // ACC //
   /////////
@@ -434,21 +926,25 @@ module otbn_alu_bignum
   // 2. Select between the ISPRs that have integrity bits and the result of the first stage.
 
   // Number of ISPRs that have integrity protection
-  localparam int NIntgIspr = 2;
+  localparam int NIntgIspr = 4;
   // IDs fpr ISPRs with integrity
-  localparam int IsprModIntg = 0;
-  localparam int IsprAccIntg = 1;
+  localparam int IsprModIntg        = 0;
+  localparam int IsprAccIntg        = 1;
+  localparam int IsprKmacMsgIntg    = 2;
+  localparam int IsprKmacDigestIntg = 3;
   // ID representing all ISPRs with no integrity
-  localparam int IsprNoIntg = 2;
+  localparam int IsprNoIntg         = 4;
 
   logic [NIntgIspr:0] ispr_rdata_intg_mux_sel;
   logic [ExtWLEN-1:0] ispr_rdata_intg_mux_in    [NIntgIspr+1];
   logic [WLEN-1:0]    ispr_rdata_no_intg_mux_in [NIspr];
 
   // First stage
-  // MOD and ACC supply their own integrity so these values are unused
-  assign ispr_rdata_no_intg_mux_in[IsprMod] = 0;
-  assign ispr_rdata_no_intg_mux_in[IsprAcc] = 0;
+  // MOD, ACC, KMAC_MSG and KMAC_DIGEST supply their own integrity so these values are unused
+  assign ispr_rdata_no_intg_mux_in[IsprMod]         = 0;
+  assign ispr_rdata_no_intg_mux_in[IsprAcc]         = 0;
+  assign ispr_rdata_no_intg_mux_in[IsprKmacMsg]     = 0;
+  assign ispr_rdata_no_intg_mux_in[IsprKmacDigest]  = 0;
 
   assign ispr_rdata_no_intg_mux_in[IsprRnd]    = rnd_data_i;
   assign ispr_rdata_no_intg_mux_in[IsprUrnd]   = urnd_data_i;
@@ -461,6 +957,8 @@ module otbn_alu_bignum
   assign ispr_rdata_no_intg_mux_in[IsprKeyS1L] = sideload_key_shares_i[1][255:0];
   assign ispr_rdata_no_intg_mux_in[IsprKeyS1H] = {{(WLEN - (SideloadKeyWidth - 256)){1'b0}},
                                                   sideload_key_shares_i[1][SideloadKeyWidth-1:256]};
+  assign ispr_rdata_no_intg_mux_in[IsprKmacCfg]     = {224'b0, kmac_cfg_intg_q[31:0]};
+  assign ispr_rdata_no_intg_mux_in[IsprKmacStatus]  = {224'b0, kmac_status_intg_q[31:0]};
 
   logic [WLEN-1:0]    ispr_rdata_no_intg;
   logic [ExtWLEN-1:0] ispr_rdata_intg_calc;
@@ -485,18 +983,25 @@ module otbn_alu_bignum
   end
 
   // Second stage
-  assign ispr_rdata_intg_mux_in[IsprModIntg] = mod_intg_q;
-  assign ispr_rdata_intg_mux_in[IsprAccIntg] = ispr_acc_intg_i;
-  assign ispr_rdata_intg_mux_in[IsprNoIntg]  = ispr_rdata_intg_calc;
+  assign ispr_rdata_intg_mux_in[IsprModIntg]        = mod_intg_q;
+  assign ispr_rdata_intg_mux_in[IsprAccIntg]        = ispr_acc_intg_i;
+  assign ispr_rdata_intg_mux_in[IsprKmacMsgIntg]    = kmac_msg_intg_q;
+  assign ispr_rdata_intg_mux_in[IsprKmacDigestIntg] = kmac_digest_intg_q;
+  assign ispr_rdata_intg_mux_in[IsprNoIntg]         = ispr_rdata_intg_calc;
 
-  assign ispr_rdata_intg_mux_sel[IsprModIntg] = ispr_predec_bignum_i.ispr_rd_en[IsprMod];
-  assign ispr_rdata_intg_mux_sel[IsprAccIntg] = ispr_predec_bignum_i.ispr_rd_en[IsprAcc];
+  assign ispr_rdata_intg_mux_sel[IsprModIntg]         = ispr_predec_bignum_i.ispr_rd_en[IsprMod];
+  assign ispr_rdata_intg_mux_sel[IsprAccIntg]         = ispr_predec_bignum_i.ispr_rd_en[IsprAcc];
+  assign ispr_rdata_intg_mux_sel[IsprKmacMsgIntg]     = ispr_predec_bignum_i.ispr_rd_en[IsprKmacMsg];
+  assign ispr_rdata_intg_mux_sel[IsprKmacDigestIntg]  = ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest];
 
   assign ispr_rdata_intg_mux_sel[IsprNoIntg]  =
     |{ispr_predec_bignum_i.ispr_rd_en[IsprKeyS1H:IsprKeyS0L],
       ispr_predec_bignum_i.ispr_rd_en[IsprUrnd],
       ispr_predec_bignum_i.ispr_rd_en[IsprFlags],
-      ispr_predec_bignum_i.ispr_rd_en[IsprRnd]};
+      ispr_predec_bignum_i.ispr_rd_en[IsprRnd],
+      ispr_predec_bignum_i.ispr_rd_en[IsprKmacCfg],
+      ispr_predec_bignum_i.ispr_rd_en[IsprKmacPartialW],
+      ispr_predec_bignum_i.ispr_rd_en[IsprKmacStatus]};
 
   // If we're reading from an ISPR we must be using the ispr_rdata_intg_mux
   `ASSERT(IsprRDataIntgMuxSelIfIsprRd_A,
@@ -955,18 +1460,26 @@ module otbn_alu_bignum
   // not none. If `shift_mod_sel` is low, `mod_intg_q` flows into `adder_y_op_b` and from there
   // into `adder_y_res`.  In this case, `mod_intg_q` is used iff  `adder_y_res` flows into
   // `operation_result_o`.
-  logic mod_used;
+  logic mod_used, kmac_used;
   assign mod_used = operation_valid_i & (operation_i.op != AluOpBignumNone)
                     & !alu_predec_bignum_i.shift_mod_sel & adder_y_res_used;
+  assign kmac_used = operation_valid_i & (operation_i.op != AluOpBignumNone) & ( |(ispr_predec_bignum_i.ispr_rd_en[IsprKmacMsg])    |
+                                                                                 |(ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest]) |
+                                                                                 |(ispr_predec_bignum_i.ispr_rd_en[IsprKmacCfg])    |
+                                                                                 |(ispr_predec_bignum_i.ispr_rd_en[IsprKmacStatus]) );
   `ASSERT_KNOWN(ModUsed_A, mod_used)
+  `ASSERT_KNOWN(KmacUsed_A, kmac_used)
 
   // Raise a register integrity violation error iff `mod_intg_q` is used and (at least partially)
   // invalid.
-  assign reg_intg_violation_err_o = mod_used & |(mod_intg_err);
+  assign reg_intg_violation_err_o = (mod_used & |(mod_intg_err)) | (kmac_used & ( |(kmac_msg_intg_err)    |
+                                                                                  |(kmac_cfg_intg_err)    |
+                                                                                  |(kmac_status_intg_err) |
+                                                                                  |(kmac_digest_intg_err) ));
   `ASSERT_KNOWN(RegIntgErrKnown_A, reg_intg_violation_err_o)
 
   // Detect and signal unexpected secure wipe signals.
-  assign sec_wipe_err_o = sec_wipe_mod_urnd_i & ~sec_wipe_running_i;
+  assign sec_wipe_err_o = (sec_wipe_kmac_regs_urnd_i | sec_wipe_mod_urnd_i) & ~sec_wipe_running_i;
 
   // Blanking Assertions
   // All blanking assertions are reset with predec_error or overall error in the whole system
@@ -1024,6 +1537,16 @@ module otbn_alu_bignum
   // MOD ISPR Blanking
   `ASSERT(BlankingIsprMod_A,
           !(|mod_wr_en) |-> ispr_mod_bignum_wdata_intg_blanked == '0,
+          clk_i, !rst_ni || ispr_predec_error_o || alu_predec_error_o || !operation_commit_i)
+
+  // KMAC CFG ISPR Blanking
+  `ASSERT(BlankingIsprKmacCfg_A,
+          !(|kmac_cfg_wr_en) |-> ispr_kmac_cfg_bignum_wdata_intg_blanked == '0,
+          clk_i, !rst_ni || ispr_predec_error_o || alu_predec_error_o || !operation_commit_i)
+
+  // KMAC MSG ISPR Blanking
+  `ASSERT(BlankingIsprKmacMsgA,
+          !((|kmac_msg_wr_en) | ispr_predec_bignum_i.ispr_wr_en[IsprKmacMsg]) |-> ispr_kmac_msg_bignum_wdata_intg_blanked == '0,
           clk_i, !rst_ni || ispr_predec_error_o || alu_predec_error_o || !operation_commit_i)
 
   // ACC ISPR Blanking

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -428,6 +428,7 @@ module otbn_alu_bignum
   logic                     kmac_cfg_ispr_wr_en;
   logic                     kmac_cfg_wr_en;
   logic [1:0]               kmac_cfg_intg_err;
+  logic                     kmac_new_cfg_q;
 
   logic [ExtWLEN-1:0] ispr_kmac_cfg_bignum_wdata_intg_blanked;
 
@@ -491,6 +492,7 @@ module otbn_alu_bignum
   logic                     kmac_pw_ispr_wr_en;
   logic                     kmac_pw_wr_en;
   logic [1:0]               kmac_pw_intg_err;
+  logic [5:0]               kmac_pw_mask;
   logic                     kmac_msg_valid_q;
   logic                     kmac_sent_last;
 
@@ -522,7 +524,7 @@ module otbn_alu_bignum
   assign kmac_pw_wr_en = (ispr_init_i | kmac_pw_ispr_wr_en) & (~kmac_msg_valid_q | kmac_sent_last);
 
   always_ff @(posedge clk_i) begin
-    if (kmac_pw_wr_en) begin
+    if (kmac_pw_wr_en | kmac_new_cfg_q) begin
       kmac_pw_intg_q  <= kmac_pw_intg_d;
     end
   end
@@ -537,12 +539,18 @@ module otbn_alu_bignum
         kmac_pw_no_intg_d = ispr_base_wdata_i;
         kmac_pw_intg_d    = kmac_pw_intg_calc;
       end
+      kmac_new_cfg_q: begin
+        kmac_pw_no_intg_d = 32'h20; // Set to full length at the start of cfg
+        kmac_pw_intg_d    = kmac_pw_intg_calc;
+      end
       default: begin
         kmac_pw_no_intg_d = 32'b0;
         kmac_pw_intg_d    = ispr_kmac_pw_bignum_wdata_intg_blanked[38:0];
       end
     endcase
   end
+
+  assign kmac_pw_mask = kmac_pw_intg_q[5:0];
 
   `ASSERT(KmacPWWrSelOneHot, $onehot0({ispr_init_i, ispr_base_wr_en_i[0]}))
 
@@ -617,8 +625,6 @@ module otbn_alu_bignum
   logic [BaseIntgWidth-1:0] kmac_status_intg_d;
   logic [31:0]              kmac_status_no_intg_d;
   logic [1:0]               kmac_status_intg_err;
-
-  logic kmac_new_cfg_q;
 
   // Error handling status for undersized message
   logic kmac_undersized_req_err;
@@ -709,8 +715,8 @@ module otbn_alu_bignum
     end
 
     assign kmac_digest_no_intg_d[i_word*32+:32] = sec_wipe_kmac_regs_urnd_i ?
-                                                    urnd_data_i[(i_word % BaseWordsPerDigestLen)*32+:32] :
-                                                    unmasked_digest_share[i_word*32+:32];
+        urnd_data_i[(i_word % BaseWordsPerDigestLen)*32+:32] :
+        unmasked_digest_share[i_word*32+:32];
 
     assign kmac_digest_wr_en[i_word] = kmac_app_rsp_i.done | sec_wipe_kmac_regs_urnd_i;
   end
@@ -790,6 +796,7 @@ module otbn_alu_bignum
   // Oversized error flag if last has already been sent and there is an additional fifo valid
   // Need to add a case when the fifo rvalid mask is greater than the last word strb
   logic last_word_oversized;
+  logic not_full_word;
   logic packer_oversized_last;
 
   assign kmac_cfg_sha3_mode       = sha3_pkg::sha3_mode_e'(kmac_cfg_intg_q[1:0]);
@@ -804,9 +811,9 @@ module otbn_alu_bignum
 
   // Create the strb for the last word in msg request
   assign kmac_last_msg_all_bytes_valid = &(~kmac_cfg_msg_len_bytes);
-  for (genvar i_bit = 1; i_bit < kmac_pkg::MsgStrbW+1; i_bit++) begin
-    assign kmac_last_msg_strb[i_bit-1] = kmac_last_msg_all_bytes_valid ? 1'b1 :
-                                         (i_bit <= kmac_cfg_msg_len_bytes) ? 1'b1 : 1'b0;
+  for (genvar i_bit = 1; i_bit < kmac_pkg::MsgStrbW+1; i_bit++) begin : gen_kmac_strb
+    assign kmac_last_msg_strb[i_bit-1] = kmac_last_msg_all_bytes_valid
+                                         | (i_bit <= kmac_cfg_msg_len_bytes);
   end
 
   // Set flag for a new KMAC cfg to indicate start/end of transaction
@@ -814,7 +821,7 @@ module otbn_alu_bignum
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       kmac_new_cfg_q <= 1'b0;
-    end else if (kmac_cfg_wr_en & ~sec_wipe_kmac_regs_urnd_i & ~ispr_init_i) begin
+    end else if (kmac_cfg_wr_en & !sec_wipe_kmac_regs_urnd_i & !ispr_init_i) begin
       kmac_new_cfg_q <= 1'b1;
     end else begin
       kmac_new_cfg_q <= 1'b0;
@@ -844,7 +851,7 @@ module otbn_alu_bignum
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       kmac_msg_valid_q <= 1'b0;
-    end else if (|(kmac_msg_wr_en) & ~sec_wipe_kmac_regs_urnd_i & ~ispr_init_i) begin
+    end else if (|(kmac_msg_wr_en) & !sec_wipe_kmac_regs_urnd_i & !ispr_init_i) begin
       kmac_msg_valid_q <= 1'b1;
     end else if (kmac_msg_fifo_wready) begin
       kmac_msg_valid_q <= 1'b0;
@@ -875,12 +882,13 @@ module otbn_alu_bignum
     end
   end
 
-  // Translates the 32-bit byte wise mask from PW WSR to 256-bit bit wise mask for APP FIFO
+  // Translates the 5-bit decimal mask from PW WSR to 256-bit bit wise mask for APP FIFO
   always_comb begin
     kmac_msg_fifo_wdata_mask = '0;
-    for (int i = 0; i < 32; i++) begin
-      if (kmac_pw_intg_q[i])
-        kmac_msg_fifo_wdata_mask[i*8 +: 8] = 8'hFF;
+    if (kmac_pw_mask == 0) begin
+      kmac_msg_fifo_wdata_mask = 256'b0;
+    end else begin
+      kmac_msg_fifo_wdata_mask = ~({256{1'b1}} << (kmac_pw_mask * 8));
     end
   end
 
@@ -900,10 +908,10 @@ module otbn_alu_bignum
   // Internal copy of otbn_controller stall signal to determine pending msg writes
   assign kmac_msg_wr_stall = (kmac_msg_write & (~kmac_msg_fifo_wready));
 
-  // When reading the return digest the message has already been sent and any remainider is cleared
+  // When reading the return digest the message has already been sent and any remainder is cleared
   assign kmac_msg_fifo_clr = kmac_sent_last
                              && (ispr_addr_i == IsprKmacDigest)
-                             && ~kmac_msg_pending_write_o;
+                             && !kmac_msg_pending_write_o;
 
   // Prim packer is used to send full words until the final word in msg request
   prim_packer #(
@@ -924,10 +932,9 @@ module otbn_alu_bignum
     .ready_i      (kmac_msg_fifo_rready),
 
     // kmac_msg_err_clr is for internal OTBN error to empty the FIFO
-    // kmac_new_cfg_q empties on new operation
     // kmac_msg_fifo_flush reads a partial word at the end of the msg
     // kmac_msg_fifo_clr ensures the fifo is empty outside of an active msg
-    .flush_i      (kmac_msg_err_clr || kmac_new_cfg_q || kmac_msg_fifo_flush || kmac_msg_fifo_clr),
+    .flush_i      (kmac_msg_err_clr || kmac_msg_fifo_flush || kmac_msg_fifo_clr),
     .flush_done_o (),
 
     .err_o        ()
@@ -953,10 +960,10 @@ module otbn_alu_bignum
     .err_o              (kmac_msg_ctr_err)
   );
 
-  // Ensure that the read mask is atleast the size of the cfg before asserting last
-  assign packer_ctr_last       = (packer_rdata_mask_cnt >= kmac_cfg_msg_len_bytes) ? 1'b1 : 1'b0;
+  // Ensure that the read mask is at least the size of the cfg before asserting last
+  assign packer_ctr_last       = (packer_rdata_mask_cnt >= kmac_cfg_msg_len_bytes);
 
-  // If it is time for the final word and their is a partial word we need to flush it out
+  // If it is time for the final word and there is a partial word we need to flush it out
   assign kmac_msg_fifo_flush   = (kmac_msg_last && (kmac_cfg_msg_len_bytes != 3'h0)
                                  && ~kmac_msg_fifo_rvalid);
 
@@ -975,26 +982,25 @@ module otbn_alu_bignum
   // fifo read iface
   assign kmac_msg_fifo_rready = (kmac_app_rsp_i.ready & ~kmac_write_cfg_to_app) | kmac_sent_last;
   assign kmac_msg_last        = (kmac_cfg_msg_len_bytes == 3'h0) ?
-                                  (kmac_msg_ctr >= kmac_cfg_msg_len_words - 1) && kmac_msg_fifo_rvalid :
-                                  ((kmac_msg_ctr >= kmac_cfg_msg_len_words) && packer_ctr_last);
+                                (kmac_msg_ctr >= kmac_cfg_msg_len_words - 1) && kmac_msg_fifo_rvalid :
+                                ((kmac_msg_ctr >= kmac_cfg_msg_len_words) && packer_ctr_last);
 
   // When there is an undersized message we artificially inject a last valid to finish the message
-  assign kmac_app_req_o.valid = (kmac_write_cfg_to_app) ?
-                                  1'b1 : (kmac_inject_last_err) ?
-                                  1'b1 : kmac_msg_fifo_rvalid && ~kmac_new_cfg_q && ~kmac_sent_last;
+  assign kmac_app_req_o.valid = (kmac_write_cfg_to_app || kmac_inject_last_err) ?
+                                1'b1 : kmac_msg_fifo_rvalid && ~kmac_new_cfg_q && ~kmac_sent_last;
 
   // The first word contains the cfg otherwise send the body
   assign kmac_app_req_o.data  = kmac_write_cfg_to_app ?
-                                  {59'b0, kmac_cfg_keccak_strength, kmac_cfg_sha3_mode} :
-                                  kmac_msg_fifo_rdata;
+                                {59'b0, kmac_cfg_keccak_strength, kmac_cfg_sha3_mode} :
+                                kmac_msg_fifo_rdata;
 
   // The strb will always be 8'hFF except for the CFG and last word
   assign kmac_app_req_o.strb  = kmac_write_cfg_to_app ?
-                                  8'h01 : kmac_app_req_o.last ?
-                                  kmac_last_msg_strb : {(kmac_pkg::MsgStrbW){1'b1}};
+                                8'h01 : kmac_app_req_o.last ?
+                                kmac_last_msg_strb : {(kmac_pkg::MsgStrbW){1'b1}};
 
   // When there is an undersized message we artifically inject a last signal to finish the message
-  assign kmac_app_req_o.last  = (kmac_inject_last_err) ? 1'b1 : kmac_msg_fifo_rvalid & kmac_msg_last;
+  assign kmac_app_req_o.last  = kmac_inject_last_err | (kmac_msg_fifo_rvalid & kmac_msg_last);
 
   // If we request an additional digest send a next to KMAC
   assign kmac_app_req_o.next  = kmac_digest_rd & ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest];
@@ -1054,7 +1060,7 @@ module otbn_alu_bignum
   always_comb begin
     kmac_err_st_d = kmac_err_st_q;
     kmac_inject_last_err = 1'b0;
-    case (kmac_err_st_q)
+    unique case (kmac_err_st_q)
       StIdle: begin
         // At the first appearance of an undersized message during a tranasaction
         // set a flag to inject an artificial last word and wait until KMAC is ready
@@ -1072,6 +1078,10 @@ module otbn_alu_bignum
           kmac_err_st_d = StIdle;
         end
       end
+      default: begin
+        kmac_err_st_d = StIdle;
+        kmac_inject_last_err = 1'b0;
+      end
     endcase
   end
 
@@ -1086,14 +1096,11 @@ module otbn_alu_bignum
 
   // The cfg reads 0 when it is a full word which means the mask is 8 so we must skip evaluation
   // at these sizes, otherwise check if mask is greater than the cfg
-  assign packer_oversized_last =
-      (packer_rdata_mask_cnt > kmac_cfg_msg_len_bytes) ?
-          ((kmac_cfg_msg_len_bytes == 4'h0 &
-            packer_rdata_mask_cnt == 4'h8) ? 1'b0 : 1'b1) :
-          1'b0;
+  assign not_full_word          = ~(packer_rdata_mask_cnt == 4'h8 & kmac_cfg_msg_len_bytes == 4'h0);
+  assign packer_oversized_last  = not_full_word & (packer_rdata_mask_cnt > kmac_cfg_msg_len_bytes);
 
   assign last_word_oversized    = kmac_msg_last & packer_oversized_last;
-  assign kmac_oversized_req_err = kmac_sent_last & kmac_msg_fifo_rvalid
+  assign kmac_oversized_req_err = kmac_sent_last & (kmac_msg_fifo_rvalid | kmac_msg_valid_q)
                                   & ~kmac_undersized_req_err_latch | last_word_oversized;
 
   /////////

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -435,12 +435,26 @@ module otbn_alu_bignum
     .data_i (kmac_cfg_no_intg_d),
     .data_o (kmac_cfg_intg_calc)
   );
+
   prim_secded_inv_39_32_dec u_kmac_cfg_secded_dec (
     .data_i     (kmac_cfg_intg_q),
     .data_o     (/* unused because we abort on any integrity error */),
     .syndrome_o (/* unused */),
     .err_o      (kmac_cfg_intg_err)
   );
+
+  prim_blanker #(.Width(ExtWLEN)) u_ispr_kmac_cfg_bignum_wdata_blanker (
+    .in_i (ispr_bignum_wdata_intg_i),
+    .en_i (ispr_predec_bignum_i.ispr_wr_en[IsprKmacCfg]),
+    .out_o(ispr_kmac_cfg_bignum_wdata_intg_blanked)
+  );
+
+  // Index 0 because only first 32-bit word contains cfg
+  assign kmac_cfg_ispr_wr_en = (ispr_addr_i == IsprKmacCfg) &
+                               (ispr_base_wr_en_i[0] | ispr_bignum_wr_en_i) &
+                               ispr_wr_commit_i;
+
+  assign kmac_cfg_wr_en = (ispr_init_i | kmac_cfg_ispr_wr_en) & !kmac_app_rsp_i.error;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -469,19 +483,6 @@ module otbn_alu_bignum
 
   `ASSERT(KmacCfgWrSelOneHot, $onehot0({ispr_init_i, ispr_base_wr_en_i[0]}))
 
-  // Index 0 because only first 32-bit word contains cfg
-  assign kmac_cfg_ispr_wr_en = (ispr_addr_i == IsprKmacCfg) &
-                               (ispr_base_wr_en_i[0] | ispr_bignum_wr_en_i) &
-                               ispr_wr_commit_i;
-
-  assign kmac_cfg_wr_en = (ispr_init_i | kmac_cfg_ispr_wr_en) & !kmac_app_rsp_i.error;
-
-  prim_blanker #(.Width(ExtWLEN)) u_ispr_kmac_cfg_bignum_wdata_blanker (
-    .in_i (ispr_bignum_wdata_intg_i),
-    .en_i (ispr_predec_bignum_i.ispr_wr_en[IsprKmacCfg]),
-    .out_o(ispr_kmac_cfg_bignum_wdata_intg_blanked)
-  );
-
   // PARTIAL WRITE
   logic [BaseIntgWidth-1:0] kmac_pw_intg_q;
   logic [31:0]              kmac_pw_no_intg_d;
@@ -491,6 +492,7 @@ module otbn_alu_bignum
   logic                     kmac_pw_wr_en;
   logic [1:0]               kmac_pw_intg_err;
   logic                     kmac_msg_valid_q;
+  logic                     kmac_sent_last;
 
   logic [ExtWLEN-1:0] ispr_kmac_pw_bignum_wdata_intg_blanked;
 
@@ -498,12 +500,26 @@ module otbn_alu_bignum
     .data_i (kmac_pw_no_intg_d),
     .data_o (kmac_pw_intg_calc)
   );
+
   prim_secded_inv_39_32_dec u_kmac_pw_secded_dec (
     .data_i     (kmac_pw_intg_q),
     .data_o     (/* unused because we abort on any integrity error */),
     .syndrome_o (/* unused */),
     .err_o      (kmac_pw_intg_err)
   );
+
+  prim_blanker #(.Width(ExtWLEN)) u_ispr_kmac_pw_bignum_wdata_blanker (
+    .in_i (ispr_bignum_wdata_intg_i),
+    .en_i (ispr_predec_bignum_i.ispr_wr_en[IsprKmacPartialW]),
+    .out_o(ispr_kmac_pw_bignum_wdata_intg_blanked)
+  );
+
+  // Index 0 because only first 32-bit word contains cfg
+  assign kmac_pw_ispr_wr_en = (ispr_addr_i == IsprKmacPartialW) &
+                              (ispr_base_wr_en_i[0] | ispr_bignum_wr_en_i) &
+                              ispr_wr_commit_i;
+
+  assign kmac_pw_wr_en = (ispr_init_i | kmac_pw_ispr_wr_en) & (~kmac_msg_valid_q | kmac_sent_last);
 
   always_ff @(posedge clk_i) begin
     if (kmac_pw_wr_en) begin
@@ -530,32 +546,18 @@ module otbn_alu_bignum
 
   `ASSERT(KmacPWWrSelOneHot, $onehot0({ispr_init_i, ispr_base_wr_en_i[0]}))
 
-  // Index 0 because only first 32-bit word contains cfg
-  assign kmac_pw_ispr_wr_en = (ispr_addr_i == IsprKmacPartialW) &
-                              (ispr_base_wr_en_i[0] | ispr_bignum_wr_en_i) &
-                              ispr_wr_commit_i;
-
-  assign kmac_pw_wr_en = (ispr_init_i | kmac_pw_ispr_wr_en) & ~kmac_msg_valid_q;
-
-  prim_blanker #(.Width(ExtWLEN)) u_ispr_kmac_pw_bignum_wdata_blanker (
-    .in_i (ispr_bignum_wdata_intg_i),
-    .en_i (ispr_predec_bignum_i.ispr_wr_en[IsprKmacPartialW]),
-    .out_o(ispr_kmac_pw_bignum_wdata_intg_blanked)
-  );
-
   // MSG
   logic [ExtWLEN-1:0]             kmac_msg_intg_q;
   logic [ExtWLEN-1:0]             kmac_msg_intg_d;
   logic [BaseWordsPerWLEN-1:0]    kmac_msg_ispr_wr_en;
   logic [BaseWordsPerWLEN-1:0]    kmac_msg_wr_en;
-
   logic [WLEN-1:0]                kmac_msg_no_intg_d;
   logic [WLEN-1:0]                kmac_msg_no_intg_q;
   logic [ExtWLEN-1:0]             kmac_msg_intg_calc;
   logic [2*BaseWordsPerWLEN-1:0]  kmac_msg_intg_err;
 
   logic                           kmac_msg_wr_stall;
-  logic                           kmac_msg_raw;
+  logic                           kmac_msg_write;
 
   logic [ExtWLEN-1:0] ispr_kmac_msg_bignum_wdata_intg_blanked;
 
@@ -576,6 +578,14 @@ module otbn_alu_bignum
       .syndrome_o (/* unused */),
       .err_o      (kmac_msg_intg_err[i_word*2+:2])
     );
+
+    assign kmac_msg_ispr_wr_en[i_word] = (ispr_addr_i == IsprKmacMsg) &
+                                         (ispr_base_wr_en_i[i_word] | ispr_bignum_wr_en_i) &
+                                         ispr_wr_commit_i;
+
+    assign kmac_msg_wr_en[i_word] = (ispr_init_i |
+                                    (kmac_msg_ispr_wr_en[i_word] & kmac_msg_write_ready_o) |
+                                    sec_wipe_kmac_regs_urnd_i) & ~kmac_msg_wr_stall;
 
     always_ff @(posedge clk_i) begin
       if (kmac_msg_wr_en[i_word]) begin
@@ -598,17 +608,9 @@ module otbn_alu_bignum
     end
 
     `ASSERT(KmacMsgWrSelOneHot, $onehot0({ispr_init_i, ispr_base_wr_en_i[i_word]}))
-
-    assign kmac_msg_ispr_wr_en[i_word] = (ispr_addr_i == IsprKmacMsg) &
-                                         (ispr_base_wr_en_i[i_word] | ispr_bignum_wr_en_i) &
-                                         ispr_wr_commit_i;
-
-    assign kmac_msg_wr_en[i_word] = (ispr_init_i |
-                                    (kmac_msg_ispr_wr_en[i_word] & kmac_msg_write_ready_o) |
-                                    sec_wipe_kmac_regs_urnd_i) & ~kmac_msg_wr_stall;
   end
 
-  assign kmac_msg_raw = (ispr_addr_i == IsprKmacMsg) & ispr_wr_commit_i;
+  assign kmac_msg_write = (ispr_addr_i == IsprKmacMsg) & ispr_wr_commit_i;
 
   // STATUS
   logic [BaseIntgWidth-1:0] kmac_status_intg_q;
@@ -618,18 +620,60 @@ module otbn_alu_bignum
 
   logic kmac_new_cfg_q;
 
-  assign kmac_status_no_intg_d = kmac_new_cfg_q ? 32'b0 : {29'b0, kmac_app_rsp_i.error, kmac_app_rsp_i.ready, kmac_app_rsp_i.done};
+  // Error handling status for undersized message
+  logic kmac_undersized_req_err;
+  logic kmac_undersized_req_err_latch;
+
+  // Error handling status for oversized message
+  logic kmac_oversized_req_err;
+  logic kmac_oversized_req_err_latch;
 
   prim_secded_inv_39_32_enc u_kmac_status_secded_enc (
     .data_i (kmac_status_no_intg_d),
     .data_o (kmac_status_intg_d)
   );
+
   prim_secded_inv_39_32_dec u_kmac_status_secded_dec (
     .data_i     (kmac_status_intg_q),
     .data_o     (/* unused because we abort on any integrity error */),
     .syndrome_o (/* unused */),
     .err_o      (kmac_status_intg_err)
   );
+
+  assign kmac_status_no_intg_d = kmac_new_cfg_q ? 32'b0 : {
+    27'b0,
+    kmac_undersized_req_err_latch,
+    kmac_oversized_req_err_latch,
+    kmac_app_rsp_i.error,
+    kmac_app_rsp_i.ready,
+    kmac_app_rsp_i.done
+  };
+
+  // If oversized err flag goes high at any point during transaction latch value into status reg
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_oversized_req_err_latch <= 1'b0;
+    end else begin
+      if (kmac_new_cfg_q) begin
+        kmac_oversized_req_err_latch <= 1'b0;
+      end else if (kmac_oversized_req_err) begin
+        kmac_oversized_req_err_latch <= 1'b1;
+      end
+    end
+  end
+
+  // If undersized err flag goes high at any point during transaction latch value into status reg
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_undersized_req_err_latch <= 1'b0;
+    end else begin
+      if (kmac_new_cfg_q) begin
+        kmac_undersized_req_err_latch <= 1'b0;
+      end else if (kmac_undersized_req_err) begin
+        kmac_undersized_req_err_latch <= 1'b1;
+      end
+    end
+  end
 
   always_ff @(posedge clk_i) begin
     kmac_status_intg_q <= kmac_status_intg_d;
@@ -645,29 +689,6 @@ module otbn_alu_bignum
   logic                                 kmac_digest_rd_next;
   logic                                 kmac_digest_valid_q;
   logic                                 kmac_digest_rd;
-
-  assign kmac_digest_valid_o = kmac_digest_valid_q & !kmac_digest_rd;
-  assign kmac_digest_rd_next = kmac_digest_rd && ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest];
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      kmac_digest_rd <= 1'b0;
-    end else if (kmac_digest_rd_next || kmac_new_cfg_q) begin
-      kmac_digest_rd <= 1'b0;
-    end else if (ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest] && kmac_digest_valid_q) begin
-      kmac_digest_rd <= 1'b1;
-    end
-  end
-
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      kmac_digest_valid_q <= 1'b0;
-    end else if (kmac_digest_rd_next || kmac_new_cfg_q) begin
-      kmac_digest_valid_q <= 1'b0;
-    end else if (kmac_app_rsp_i.done) begin
-      kmac_digest_valid_q <= 1'b1;
-    end
-  end
 
   for (genvar i_word = 0; i_word < BaseWordsPerDigestLen; i_word++) begin : g_kmac_digest_words
     prim_secded_inv_39_32_enc i_kmac_digest_secded_enc (
@@ -694,6 +715,29 @@ module otbn_alu_bignum
     assign kmac_digest_wr_en[i_word] = kmac_app_rsp_i.done | sec_wipe_kmac_regs_urnd_i;
   end
 
+  assign kmac_digest_valid_o = kmac_digest_valid_q & !kmac_digest_rd;
+  assign kmac_digest_rd_next = kmac_digest_rd && ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest];
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_digest_rd <= 1'b0;
+    end else if (kmac_digest_rd_next || kmac_new_cfg_q) begin
+      kmac_digest_rd <= 1'b0;
+    end else if (ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest] && kmac_digest_valid_q) begin
+      kmac_digest_rd <= 1'b1;
+    end
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_digest_valid_q <= 1'b0;
+    end else if (kmac_digest_rd_next || kmac_new_cfg_q) begin
+      kmac_digest_valid_q <= 1'b0;
+    end else if (kmac_app_rsp_i.done) begin
+      kmac_digest_valid_q <= 1'b1;
+    end
+  end
+
   // Digest shares are xor'ed to get the unmasked share value
   // If KMAC is operating in unmasked mode then share1 is '0 and xor remains the unmasked val
   assign unmasked_digest_share = kmac_app_rsp_i.digest_share0 ^ kmac_app_rsp_i.digest_share1;
@@ -707,7 +751,7 @@ module otbn_alu_bignum
   logic [2:0]                     kmac_cfg_msg_len_bytes;
   logic [11:0]                    kmac_msg_ctr;
 
-  logic                           kmac_msg_clr;
+  logic                           kmac_msg_err_clr;
   logic                           kmac_msg_fifo_wvalid;
   logic                           kmac_msg_fifo_wready;
   logic [WLEN-1:0]                kmac_msg_fifo_wdata;
@@ -717,7 +761,7 @@ module otbn_alu_bignum
   logic [kmac_pkg::MsgWidth-1:0]  kmac_msg_fifo_rdata;
   logic [kmac_pkg::MsgWidth-1:0]  kmac_msg_fifo_rdata_mask;
   logic                           kmac_msg_fifo_flush;
-  logic [kmac_pkg::MsgStrbW-1:0]  kmac_msg_strb;
+  logic                           kmac_msg_fifo_clr;
   logic                           kmac_last_msg_all_bytes_valid;
   logic [kmac_pkg::MsgStrbW-1:0]  kmac_last_msg_strb;
 
@@ -735,20 +779,38 @@ module otbn_alu_bignum
   logic kmac_app_cfg_sent;
   logic kmac_msg_fifo_pending;
 
+  // Oversized and undersized msg handling
+  logic kmac_msg_req_err;
+  logic kmac_pending_last;
+  logic kmac_inject_last_err;
+  logic kmac_undersized_req_err_q;
+  logic kmac_undersized_req_err_pe;
+
+  kmac_undersized_state_e kmac_err_st_d, kmac_err_st_q;
+  // Oversized error flag if last has already been sent and there is an additional fifo valid
+  // Need to add a case when the fifo rvalid mask is greater than the last word strb
+  logic last_word_oversized;
+  logic packer_oversized_last;
+
   assign kmac_cfg_sha3_mode       = sha3_pkg::sha3_mode_e'(kmac_cfg_intg_q[1:0]);
   assign kmac_cfg_keccak_strength = sha3_pkg::keccak_strength_e'(kmac_cfg_intg_q[4:2]);
   assign kmac_cfg_done            = kmac_cfg_intg_q[31];
   assign kmac_cfg_msg_len         = kmac_cfg_intg_q[19:5];
   assign kmac_cfg_msg_len_words   = kmac_cfg_msg_len[14:3];
   assign kmac_cfg_msg_len_bytes   = kmac_cfg_msg_len[2:0];
-  assign kmac_msg_clr             = kmac_app_rsp_i.error | sec_wipe_kmac_regs_urnd_i | kmac_msg_ctr_err;
+  assign kmac_msg_err_clr         = kmac_app_rsp_i.error
+                                    | sec_wipe_kmac_regs_urnd_i
+                                    | kmac_msg_ctr_err;
 
+  // Create the strb for the last word in msg request
   assign kmac_last_msg_all_bytes_valid = &(~kmac_cfg_msg_len_bytes);
   for (genvar i_bit = 1; i_bit < kmac_pkg::MsgStrbW+1; i_bit++) begin
     assign kmac_last_msg_strb[i_bit-1] = kmac_last_msg_all_bytes_valid ? 1'b1 :
-                                            (i_bit <= kmac_cfg_msg_len_bytes) ? 1'b1 : 1'b0;
+                                         (i_bit <= kmac_cfg_msg_len_bytes) ? 1'b1 : 1'b0;
   end
 
+  // Set flag for a new KMAC cfg to indicate start/end of transaction
+  // Used to ensure FIFO is flushed and set bounds of transaction
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       kmac_new_cfg_q <= 1'b0;
@@ -759,6 +821,9 @@ module otbn_alu_bignum
     end
   end
 
+  // Set cfg and msg status flags for transaction
+  // CFG is active from start of config until end of transaction
+  // MSG is active after the cfg word is sent
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       kmac_msg_active_q <= 1'b0;
@@ -766,7 +831,7 @@ module otbn_alu_bignum
     end else if (kmac_new_cfg_q) begin
       kmac_msg_active_q <= 1'b0;
       kmac_cfg_active_q <= 1'b1;
-    end else if (kmac_msg_clr || kmac_idle_q) begin
+    end else if (kmac_msg_err_clr || kmac_idle_q) begin
       kmac_msg_active_q <= 1'b0;
       kmac_cfg_active_q <= 1'b0;
     end else if (kmac_msg_fifo_wready) begin //kmac_app_cfg_sent
@@ -774,6 +839,8 @@ module otbn_alu_bignum
     end
   end
 
+  // Message is valid when there is ISPR write to the MSG WSR
+  // Value is held until it is written into the fifo at the first wready signal
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       kmac_msg_valid_q <= 1'b0;
@@ -784,6 +851,7 @@ module otbn_alu_bignum
     end
   end
 
+  // KMAC is idle when CFG WSR bit [31] is 1
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       kmac_idle_q <= 1'b1;
@@ -794,10 +862,7 @@ module otbn_alu_bignum
     end
   end
 
-  assign kmac_msg_wr_stall = (kmac_msg_raw & (~kmac_msg_fifo_wready));
-
-  assign kmac_write_cfg_to_app = kmac_cfg_active_q && (~kmac_msg_active_q | ~kmac_app_cfg_sent) && ~kmac_idle_q;
-
+  // Internal status flag to track when the configuration word has been sent to KMAC
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       kmac_app_cfg_sent <= 1'b0;
@@ -810,6 +875,7 @@ module otbn_alu_bignum
     end
   end
 
+  // Translates the 32-bit byte wise mask from PW WSR to 256-bit bit wise mask for APP FIFO
   always_comb begin
     kmac_msg_fifo_wdata_mask = '0;
     for (int i = 0; i < 32; i++) begin
@@ -818,24 +884,28 @@ module otbn_alu_bignum
     end
   end
 
+  // Convert the number of 1's in byte mask to decimal value for comparison
+  // with CFG WSR partial word byte field
   always_comb begin
-    for (int i = 0; i < kmac_pkg::MsgStrbW; i++) begin
-      kmac_msg_strb[i] = |kmac_msg_fifo_rdata_mask[i*8 +: 8];
-    end
-  end
-
-  always_comb begin
+    packer_rdata_mask_cnt = '0;
     for (int i = 0; i < kmac_pkg::MsgStrbW; i++) begin
       // collapse each 8-bit chunk into one strb bit
       packer_rdata_mask[i] = |kmac_msg_fifo_rdata_mask[i*8 +: 8];
     end
-    packer_rdata_mask_cnt = $countones(packer_rdata_mask);
+    foreach (packer_rdata_mask[i]) begin
+      packer_rdata_mask_cnt += packer_rdata_mask[i];
+    end
   end
 
-  assign packer_ctr_last = (kmac_cfg_msg_len_bytes == packer_rdata_mask_cnt) ? 1'b1 : 1'b0;
+  // Internal copy of otbn_controller stall signal to determine pending msg writes
+  assign kmac_msg_wr_stall = (kmac_msg_write & (~kmac_msg_fifo_wready));
 
-  assign kmac_msg_fifo_flush = (kmac_msg_last && (kmac_cfg_msg_len_bytes != 3'h0));
+  // When reading the return digest the message has already been sent and any remainider is cleared
+  assign kmac_msg_fifo_clr = kmac_sent_last
+                             && (ispr_addr_i == IsprKmacDigest)
+                             && ~kmac_msg_pending_write_o;
 
+  // Prim packer is used to send full words until the final word in msg request
   prim_packer #(
     .InW  (WLEN),
     .OutW (kmac_pkg::MsgWidth)
@@ -853,12 +923,17 @@ module otbn_alu_bignum
     .mask_o       (kmac_msg_fifo_rdata_mask),
     .ready_i      (kmac_msg_fifo_rready),
 
-    .flush_i      (kmac_msg_clr || kmac_new_cfg_q || kmac_msg_fifo_flush),
+    // kmac_msg_err_clr is for internal OTBN error to empty the FIFO
+    // kmac_new_cfg_q empties on new operation
+    // kmac_msg_fifo_flush reads a partial word at the end of the msg
+    // kmac_msg_fifo_clr ensures the fifo is empty outside of an active msg
+    .flush_i      (kmac_msg_err_clr || kmac_new_cfg_q || kmac_msg_fifo_flush || kmac_msg_fifo_clr),
     .flush_done_o (),
 
     .err_o        ()
   );
 
+  // Prim counter is used to keep track of the message size sent
   prim_count #(
     .Width (12),
     .EnableAlertTriggerSVA('0)
@@ -866,7 +941,7 @@ module otbn_alu_bignum
     .clk_i,
     .rst_ni,
 
-    .clr_i              (kmac_msg_clr || kmac_new_cfg_q),
+    .clr_i              (kmac_msg_err_clr || kmac_new_cfg_q || kmac_sent_last),
     .set_i              (1'b0),
     .set_cnt_i          ({(12){1'b0}}),
     .incr_en_i          (kmac_msg_fifo_rvalid & kmac_app_rsp_i.ready & kmac_msg_fifo_rready),
@@ -878,24 +953,148 @@ module otbn_alu_bignum
     .err_o              (kmac_msg_ctr_err)
   );
 
+  // Ensure that the read mask is atleast the size of the cfg before asserting last
+  assign packer_ctr_last       = (packer_rdata_mask_cnt >= kmac_cfg_msg_len_bytes) ? 1'b1 : 1'b0;
+
+  // If it is time for the final word and their is a partial word we need to flush it out
+  assign kmac_msg_fifo_flush   = (kmac_msg_last && (kmac_cfg_msg_len_bytes != 3'h0)
+                                 && ~kmac_msg_fifo_rvalid);
+
+  assign kmac_write_cfg_to_app =  kmac_cfg_active_q
+                                  && (~kmac_msg_active_q | ~kmac_app_cfg_sent)
+                                  && ~kmac_idle_q;
+
   // fifo write iface
   assign kmac_msg_fifo_wdata      = kmac_msg_no_intg_q;
-  assign kmac_msg_fifo_wvalid     = kmac_msg_valid_q & kmac_msg_fifo_wready;
+  assign kmac_msg_fifo_wvalid     = kmac_msg_valid_q && kmac_msg_fifo_wready
+                                    && ~kmac_msg_fifo_flush && ~kmac_sent_last && (~kmac_msg_last);
+
   assign kmac_msg_write_ready_o   = kmac_msg_fifo_wready;
-  assign kmac_msg_pending_write_o = kmac_msg_valid_q;
+  assign kmac_msg_pending_write_o = kmac_msg_valid_q && ~kmac_sent_last;
 
   // fifo read iface
-  assign kmac_msg_last = (kmac_cfg_msg_len_bytes == 3'h0) ? (kmac_msg_ctr >= kmac_cfg_msg_len_words - 1) : ((kmac_msg_ctr >= kmac_cfg_msg_len_words) && packer_ctr_last);
-  assign kmac_msg_fifo_rready = kmac_app_rsp_i.ready & ~kmac_write_cfg_to_app; //kmac_app_cfg_sent
-  assign kmac_app_req_o.valid = (kmac_write_cfg_to_app) ? 1'b1 : kmac_msg_fifo_rvalid & ~kmac_new_cfg_q; //kmac_app_cfg_sent
+  assign kmac_msg_fifo_rready = (kmac_app_rsp_i.ready & ~kmac_write_cfg_to_app) | kmac_sent_last;
+  assign kmac_msg_last        = (kmac_cfg_msg_len_bytes == 3'h0) ?
+                                  (kmac_msg_ctr >= kmac_cfg_msg_len_words - 1) && kmac_msg_fifo_rvalid :
+                                  ((kmac_msg_ctr >= kmac_cfg_msg_len_words) && packer_ctr_last);
+
+  // When there is an undersized message we artificially inject a last valid to finish the message
+  assign kmac_app_req_o.valid = (kmac_write_cfg_to_app) ?
+                                  1'b1 : (kmac_inject_last_err) ?
+                                  1'b1 : kmac_msg_fifo_rvalid && ~kmac_new_cfg_q && ~kmac_sent_last;
+
+  // The first word contains the cfg otherwise send the body
   assign kmac_app_req_o.data  = kmac_write_cfg_to_app ?
                                   {59'b0, kmac_cfg_keccak_strength, kmac_cfg_sha3_mode} :
                                   kmac_msg_fifo_rdata;
+
+  // The strb will always be 8'hFF except for the CFG and last word
   assign kmac_app_req_o.strb  = kmac_write_cfg_to_app ?
-                                  8'h01 : kmac_app_req_o.last ? kmac_msg_strb : {(kmac_pkg::MsgStrbW){1'b1}};
-  assign kmac_app_req_o.last  = kmac_msg_fifo_rvalid & kmac_msg_last;
+                                  8'h01 : kmac_app_req_o.last ?
+                                  kmac_last_msg_strb : {(kmac_pkg::MsgStrbW){1'b1}};
+
+  // When there is an undersized message we artifically inject a last signal to finish the message
+  assign kmac_app_req_o.last  = (kmac_inject_last_err) ? 1'b1 : kmac_msg_fifo_rvalid & kmac_msg_last;
+
+  // If we request an additional digest send a next to KMAC
   assign kmac_app_req_o.next  = kmac_digest_rd & ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest];
+
+  // Hold will remain active for duration of transaction unless an internal error occurs
   assign kmac_app_req_o.hold  = kmac_cfg_active_q & ~kmac_new_cfg_q & ~kmac_cfg_done;
+
+  // check for incomplete msg with pending digest
+  // Latch for last in current transaction
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_pending_last = 1'b0;
+      kmac_sent_last = 1'b0;
+    end else begin
+      // Either we observed a valid last or we artificially created a last
+      if ((kmac_msg_fifo_rvalid & kmac_msg_last) | kmac_inject_last_err) begin
+        kmac_pending_last = 1'b1; // Prepared to send the final word
+        if (kmac_app_rsp_i.ready) begin
+          kmac_sent_last = 1'b1;
+        end
+      end else if (kmac_cfg_wr_en) begin
+        // Clear any last flags after a new cfg is written
+        kmac_pending_last = 1'b0;
+        kmac_sent_last = 1'b0;
+      end
+    end
+  end
+
+  // If current instruction is KMAC Digest check if KMAC received all data
+  // There should be no outstanding transactions to write into the FIFO
+  // There should not be any new words being written or read to/from the FIFO
+  // The FIFO should not be in a flush cycle
+  always_comb begin
+    kmac_msg_req_err = 1'b0;
+    if (ispr_addr_i == IsprKmacDigest && kmac_app_req_o.hold) begin
+      kmac_msg_req_err = (!kmac_msg_pending_write_o && !kmac_msg_fifo_rvalid
+                         && !kmac_msg_fifo_flush && !kmac_msg_fifo_wvalid);
+    end
+  end
+
+  // If we have not received a last see if there is an error
+  assign kmac_undersized_req_err = kmac_msg_req_err & ~kmac_pending_last;
+
+  // Register the undersized req err to compute a posedge
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_undersized_req_err_q <= 1'b0;
+    end else begin
+      kmac_undersized_req_err_q <= kmac_undersized_req_err;
+    end
+  end
+
+  // Posedge of undersize kmac req err
+  assign kmac_undersized_req_err_pe = ~kmac_undersized_req_err_q && kmac_undersized_req_err;
+
+  // Combinatorial state machine for oversized message computation
+  always_comb begin
+    kmac_err_st_d = kmac_err_st_q;
+    kmac_inject_last_err = 1'b0;
+    case (kmac_err_st_q)
+      StIdle: begin
+        // At the first appearance of an undersized message during a tranasaction
+        // set a flag to inject an artificial last word and wait until KMAC is ready
+        if (kmac_undersized_req_err_pe) begin
+          kmac_inject_last_err = 1'b1;
+          if (~kmac_app_rsp_i.ready) begin
+            kmac_err_st_d = StPendingReady;
+          end
+        end
+      end
+      StPendingReady: begin
+        // Continue holding last word until acknowledgement from KMAC
+        kmac_inject_last_err = 1'b1;
+        if (kmac_app_rsp_i.ready) begin
+          kmac_err_st_d = StIdle;
+        end
+      end
+    endcase
+  end
+
+  // Register the state
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      kmac_err_st_q <= StIdle;
+    end else begin
+      kmac_err_st_q <= kmac_err_st_d;
+    end
+  end
+
+  // The cfg reads 0 when it is a full word which means the mask is 8 so we must skip evaluation
+  // at these sizes, otherwise check if mask is greater than the cfg
+  assign packer_oversized_last =
+      (packer_rdata_mask_cnt > kmac_cfg_msg_len_bytes) ?
+          ((kmac_cfg_msg_len_bytes == 4'h0 &
+            packer_rdata_mask_cnt == 4'h8) ? 1'b0 : 1'b1) :
+          1'b0;
+
+  assign last_word_oversized    = kmac_msg_last & packer_oversized_last;
+  assign kmac_oversized_req_err = kmac_sent_last & kmac_msg_fifo_rvalid
+                                  & ~kmac_undersized_req_err_latch | last_word_oversized;
 
   /////////
   // ACC //

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -1,4 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192)
+// Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -142,6 +145,11 @@ module otbn_controller
 
   input  logic urnd_reseed_err_i,
 
+  // KMAC interface
+  input  logic kmac_msg_write_ready_i,
+  input  logic kmac_msg_pending_write_i,
+  input  logic kmac_digest_valid_i,
+
   // Secure Wipe
   output logic secure_wipe_req_o,
   input  logic secure_wipe_ack_i,
@@ -202,6 +210,7 @@ module otbn_controller
 
   logic stall;
   logic ispr_stall;
+  logic kmac_write_stall;
   logic mem_stall;
   logic rf_indirect_stall;
   logic jump_or_branch;
@@ -245,6 +254,9 @@ module otbn_controller
   logic                     lsu_predec_error, branch_target_predec_error, ctrl_predec_error;
 
   logic rnd_req_raw;
+  logic kmac_digest_req_raw;
+  logic kmac_msg_write_req_raw;
+  logic kmac_msg_partial_raw;
 
   // Register read data with integrity stripped off
   logic [31:0]     rf_base_rd_data_a_no_intg;
@@ -367,8 +379,13 @@ module otbn_controller
   // required on stores as there is no response to deal with.
   assign mem_stall = lsu_load_req_raw;
 
-  // Reads to RND must stall until data is available
-  assign ispr_stall = rnd_req_raw & ~rnd_valid_i;
+  // Reads to RND must stall until data is available.
+  // Also, writes to the KMAC_MSG register are only
+  // allowed, if it can accept new data.
+  assign ispr_stall = (rnd_req_raw & ~rnd_valid_i) | (kmac_digest_req_raw & ~kmac_digest_valid_i);
+
+  assign kmac_write_stall = (kmac_msg_write_req_raw & ~kmac_msg_write_ready_i)
+                            | (kmac_msg_partial_raw & kmac_msg_pending_write_i);
 
   assign rf_indirect_stall = insn_valid_i &
                              (state_q != OtbnStateStall) &
@@ -377,7 +394,7 @@ module otbn_controller
                               insn_dec_bignum_i.rf_b_indirect |
                               insn_dec_bignum_i.rf_d_indirect);
 
-  assign stall = mem_stall | ispr_stall | rf_indirect_stall;
+  assign stall = mem_stall | ispr_stall | rf_indirect_stall | kmac_write_stall;
 
   // OTBN is done when it was executing something (in state OtbnStateRun or OtbnStateStall)
   // and either it executes an ecall or an error occurs. A pulse on the done signal raises the
@@ -967,7 +984,7 @@ module otbn_controller
     .out_o(rf_bignum_rd_addr_a_o)
   );
 
-  assign rf_bignum_rd_en_a_unbuf = insn_dec_bignum_i.rf_ren_a & insn_valid_i & ~stall;
+  assign rf_bignum_rd_en_a_unbuf = insn_dec_bignum_i.rf_ren_a & insn_valid_i & (~stall | kmac_write_stall);
 
   prim_buf #(
     .Width(1)
@@ -1068,7 +1085,7 @@ module otbn_controller
 
     // Only write if valid instruction wants a bignum rf write and it isn't stalled. If instruction
     // doesn't execute (e.g. due to an error) the write won't commit.
-    if (insn_valid_i && insn_dec_bignum_i.rf_we && !rf_indirect_stall) begin
+    if (insn_valid_i && insn_dec_bignum_i.rf_we && !rf_indirect_stall && !kmac_write_stall) begin
       if (insn_dec_bignum_i.mac_en && insn_dec_bignum_i.mac_shift_out) begin
         // Special handling for BN.MULQACC.SO, only enable upper or lower half depending on
         // mac_wr_hw_sel_upper.
@@ -1260,6 +1277,23 @@ module otbn_controller
         // Reading from RND_PREFETCH results in 0, there is no ISPR to read so no address is set.
         // The csr_rdata mux logic takes care of producing the 0.
       end
+      CsrKmacCfg: begin
+        ispr_addr_base      = IsprKmacCfg;
+        ispr_word_addr_base = '0;
+      end
+      CsrKmacStatus: begin
+        ispr_addr_base      = IsprKmacStatus;
+        ispr_word_addr_base = '0;
+      end
+      CsrKmacDigestW0, CsrKmacDigestW1, CsrKmacDigestW2, CsrKmacDigestW3,
+      CsrKmacDigestW4, CsrKmacDigestW5, CsrKmacDigestW6, CsrKmacDigestW7: begin
+        ispr_addr_base      = IsprKmacDigest;
+        ispr_word_addr_base = csr_sub_addr;
+      end
+      CsrKmacPartialW: begin
+        ispr_addr_base      = IsprKmacPartialW;
+        ispr_word_addr_base = '0;
+      end
       CsrRnd: begin
         ispr_addr_base      = IsprRnd;
         ispr_word_addr_base = '0;
@@ -1397,6 +1431,9 @@ module otbn_controller
       WsrRnd:  ispr_addr_bignum = IsprRnd;
       WsrUrnd: ispr_addr_bignum = IsprUrnd;
       WsrAcc:  ispr_addr_bignum = IsprAcc;
+      WsrKmacMsg: ispr_addr_bignum = IsprKmacMsg;
+      WsrKmacCfg: ispr_addr_bignum = IsprKmacCfg;
+      WsrKmacDigest: ispr_addr_bignum = IsprKmacDigest;
       WsrKeyS0L: begin
         ispr_addr_bignum = IsprKeyS0L;
         key_invalid = ~sideload_key_shares_valid_i[0];
@@ -1558,6 +1595,9 @@ module otbn_controller
                                             dmem_addr_unaligned_bignum |
                                             dmem_addr_unaligned_base);
 
+  assign kmac_digest_req_raw = insn_valid_i & ispr_rd_insn & (ispr_addr_o == IsprKmacDigest);
+  assign kmac_msg_write_req_raw = insn_valid_i & ispr_wr_insn & (ispr_addr_o == IsprKmacMsg);
+  assign kmac_msg_partial_raw = insn_valid_i & ispr_wr_insn & (ispr_addr_o == IsprKmacPartialW);
   assign rnd_req_raw = insn_valid_i & ispr_rd_insn & (ispr_addr_o == IsprRnd);
   // Don't factor rnd_rep/fips_err_i into rnd_req_o. This would lead to a combo loop.
   assign rnd_req_o = rnd_req_raw & insn_valid_i & ~(software_err | fatal_err);

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -298,8 +298,8 @@ module otbn_controller
   logic [11:0] loop_bodysize;
   logic [31:0] loop_iterations;
 
-  // Loop generated jumps. The loop controller asks to jump when execution reaches the end of a loop
-  // body that hasn't completed all of its iterations.
+  // Loop generated jumps. The loop controller asks to jump when execution reaches the end of a
+  // loop body that hasn't completed all of its iterations.
   logic                     loop_jump;
   logic [ImemAddrWidth-1:0] loop_jump_addr;
 
@@ -984,7 +984,9 @@ module otbn_controller
     .out_o(rf_bignum_rd_addr_a_o)
   );
 
-  assign rf_bignum_rd_en_a_unbuf = insn_dec_bignum_i.rf_ren_a & insn_valid_i & (~stall | kmac_write_stall);
+  assign rf_bignum_rd_en_a_unbuf = insn_dec_bignum_i.rf_ren_a
+      & insn_valid_i
+      & (~stall | kmac_write_stall);
 
   prim_buf #(
     .Width(1)

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -381,7 +381,7 @@ module otbn_controller
 
   // Reads to RND must stall until data is available.
   // Also, writes to the KMAC_MSG register are only
-  // allowed, if it can accept new data.
+  // allowed if it can accept new data.
   assign ispr_stall = (rnd_req_raw & ~rnd_valid_i) | (kmac_digest_req_raw & ~kmac_digest_valid_i);
 
   assign kmac_write_stall = (kmac_msg_write_req_raw & ~kmac_msg_write_ready_i)

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -1,4 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192)
+// Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -95,7 +98,11 @@ module otbn_core
   input logic software_errs_fatal_i,
 
   input logic [1:0]                       sideload_key_shares_valid_i,
-  input logic [1:0][SideloadKeyWidth-1:0] sideload_key_shares_i
+  input logic [1:0][SideloadKeyWidth-1:0] sideload_key_shares_i,
+
+  // KMAC AppIntf
+  output kmac_pkg::app_req_t kmac_app_req_o,
+  input  kmac_pkg::app_rsp_t kmac_app_rsp_i
 );
   import prim_mubi_pkg::*;
 
@@ -249,6 +256,10 @@ module otbn_core
   logic        insn_cnt_clear_int;
   logic [31:0] insn_cnt;
 
+  logic kmac_msg_write_ready;
+  logic kmac_msg_pending_write;
+  logic kmac_digest_valid;
+
   logic secure_wipe_req, secure_wipe_ack;
 
   logic sec_wipe_wdr_d, sec_wipe_wdr_q;
@@ -259,6 +270,7 @@ module otbn_core
 
   logic sec_wipe_acc_urnd;
   logic sec_wipe_mod_urnd;
+  logic sec_wipe_kmac_regs_urnd;
   logic sec_wipe_zero;
   logic sec_wipe_err;
 
@@ -317,9 +329,10 @@ module otbn_core
     .sec_wipe_base_urnd_o(sec_wipe_base_urnd),
     .sec_wipe_addr_o     (sec_wipe_addr),
 
-    .sec_wipe_acc_urnd_o(sec_wipe_acc_urnd),
-    .sec_wipe_mod_urnd_o(sec_wipe_mod_urnd),
-    .sec_wipe_zero_o    (sec_wipe_zero),
+    .sec_wipe_acc_urnd_o      (sec_wipe_acc_urnd),
+    .sec_wipe_mod_urnd_o      (sec_wipe_mod_urnd),
+    .sec_wipe_kmac_regs_urnd_o(sec_wipe_kmac_regs_urnd),
+    .sec_wipe_zero_o          (sec_wipe_zero),
 
     .ispr_init_o         (ispr_init),
     .state_reset_o       (state_reset),
@@ -550,6 +563,11 @@ module otbn_core
     .rnd_valid_i       (rnd_valid),
 
     .urnd_reseed_err_i(urnd_reseed_err),
+
+    // KMAC interface
+    .kmac_msg_write_ready_i   (kmac_msg_write_ready),
+    .kmac_msg_pending_write_i (kmac_msg_pending_write),
+    .kmac_digest_valid_i      (kmac_digest_valid),
 
     // Secure wipe
     .secure_wipe_req_o     (secure_wipe_req),
@@ -850,9 +868,10 @@ module otbn_core
 
     .reg_intg_violation_err_o(alu_bignum_reg_intg_violation_err),
 
-    .sec_wipe_mod_urnd_i(sec_wipe_mod_urnd),
-    .sec_wipe_running_i (secure_wipe_running_o),
-    .sec_wipe_err_o     (alu_bignum_sec_wipe_err),
+    .sec_wipe_mod_urnd_i      (sec_wipe_mod_urnd),
+    .sec_wipe_kmac_regs_urnd_i(sec_wipe_kmac_regs_urnd),
+    .sec_wipe_running_i       (secure_wipe_running_o),
+    .sec_wipe_err_o           (alu_bignum_sec_wipe_err),
 
     .mac_operation_flags_i   (mac_bignum_operation_flags),
     .mac_operation_flags_en_i(mac_bignum_operation_flags_en),
@@ -861,6 +880,13 @@ module otbn_core
     .urnd_data_i(urnd_data),
 
     .sideload_key_shares_i,
+
+    .kmac_msg_write_ready_o   (kmac_msg_write_ready),
+    .kmac_msg_pending_write_o (kmac_msg_pending_write),
+    .kmac_digest_valid_o      (kmac_digest_valid),
+
+    .kmac_app_rsp_i,
+    .kmac_app_req_o,
 
     .alu_predec_error_o(alu_bignum_predec_error),
     .ispr_predec_error_o(ispr_predec_error)

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -565,9 +565,9 @@ module otbn_core
     .urnd_reseed_err_i(urnd_reseed_err),
 
     // KMAC interface
-    .kmac_msg_write_ready_i   (kmac_msg_write_ready),
-    .kmac_msg_pending_write_i (kmac_msg_pending_write),
-    .kmac_digest_valid_i      (kmac_digest_valid),
+    .kmac_msg_write_ready_i  (kmac_msg_write_ready),
+    .kmac_msg_pending_write_i(kmac_msg_pending_write),
+    .kmac_digest_valid_i     (kmac_digest_valid),
 
     // Secure wipe
     .secure_wipe_req_o     (secure_wipe_req),
@@ -881,9 +881,9 @@ module otbn_core
 
     .sideload_key_shares_i,
 
-    .kmac_msg_write_ready_o   (kmac_msg_write_ready),
-    .kmac_msg_pending_write_o (kmac_msg_pending_write),
-    .kmac_digest_valid_o      (kmac_digest_valid),
+    .kmac_msg_write_ready_o  (kmac_msg_write_ready),
+    .kmac_msg_pending_write_o(kmac_msg_pending_write),
+    .kmac_digest_valid_o     (kmac_digest_valid),
 
     .kmac_app_rsp_i,
     .kmac_app_req_o,

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -1,4 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192)
+// Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,6 +22,15 @@ package otbn_pkg;
 
   // Number of 32-bit words per WLEN
   parameter int BaseWordsPerWLEN = WLEN / 32;
+
+  // Digest Register Length
+  parameter int DigestRegLen = 256;
+
+  // "Extended" Digest WLEN: size of digest with added integrity bits
+  parameter int ExtDigestLen = DigestRegLen * 39 / 32;
+
+  // Number of 32-bit words per Digest
+  parameter int BaseWordsPerDigestLen = DigestRegLen / 32;
 
   // Number of flag groups
   parameter int NFlagGroups = 2;
@@ -323,6 +335,17 @@ package otbn_pkg;
     CsrMod6        = 12'h7D6,
     CsrMod7        = 12'h7D7,
     CsrRndPrefetch = 12'h7D8,
+    CsrKmacCfg     = 12'h7D9,
+    CsrKmacStatus  = 12'h7E2,
+    CsrKmacDigestW0 = 12'h7E3,
+    CsrKmacDigestW1 = 12'h7E4,
+    CsrKmacDigestW2 = 12'h7E5,
+    CsrKmacDigestW3 = 12'h7E6,
+    CsrKmacDigestW4 = 12'h7E7,
+    CsrKmacDigestW5 = 12'h7E8,
+    CsrKmacDigestW6 = 12'h7E9,
+    CsrKmacDigestW7 = 12'h7EA,
+    CsrKmacPartialW = 12'h7F3,
 
     // 0xFC0-0xFFF Custom read-only
     CsrRnd         = 12'hFC0,
@@ -330,34 +353,42 @@ package otbn_pkg;
   } csr_e;
 
   // Wide Special Purpose Registers (WSRs)
-  parameter int NWsr = 8; // Number of WSRs
+  parameter int NWsr = 11; // Number of WSRs
   parameter int WsrNumWidth = $clog2(NWsr);
   typedef enum logic [WsrNumWidth-1:0] {
-    WsrMod    = 'd0,
-    WsrRnd    = 'd1,
-    WsrUrnd   = 'd2,
-    WsrAcc    = 'd3,
-    WsrKeyS0L = 'd4,
-    WsrKeyS0H = 'd5,
-    WsrKeyS1L = 'd6,
-    WsrKeyS1H = 'd7
+    WsrMod          = 'd0,
+    WsrRnd          = 'd1,
+    WsrUrnd         = 'd2,
+    WsrAcc          = 'd3,
+    WsrKeyS0L       = 'd4,
+    WsrKeyS0H       = 'd5,
+    WsrKeyS1L       = 'd6,
+    WsrKeyS1H       = 'd7,
+    WsrKmacCfg      = 'd8,
+    WsrKmacMsg      = 'd9,
+    WsrKmacDigest   = 'd10
   } wsr_e;
 
   // Internal Special Purpose Registers (ISPRs)
   // CSRs and WSRs have some overlap into what they map into. ISPRs are the actual registers in the
   // design which CSRs and WSRs are mapped on to.
-  parameter int NIspr = 9;
+  parameter int NIspr = 14;
   parameter int IsprNumWidth = $clog2(NIspr);
   typedef enum logic [IsprNumWidth-1:0] {
-    IsprMod    = 'd0,
-    IsprRnd    = 'd1,
-    IsprAcc    = 'd2,
-    IsprFlags  = 'd3,
-    IsprUrnd   = 'd4,
-    IsprKeyS0L = 'd5,
-    IsprKeyS0H = 'd6,
-    IsprKeyS1L = 'd7,
-    IsprKeyS1H = 'd8
+    IsprMod           = 'd0,
+    IsprRnd           = 'd1,
+    IsprAcc           = 'd2,
+    IsprFlags         = 'd3,
+    IsprUrnd          = 'd4,
+    IsprKeyS0L        = 'd5,
+    IsprKeyS0H        = 'd6,
+    IsprKeyS1L        = 'd7,
+    IsprKeyS1H        = 'd8,
+    IsprKmacCfg       = 'd9,
+    IsprKmacMsg       = 'd10,
+    IsprKmacStatus    = 'd11,
+    IsprKmacDigest    = 'd12,
+    IsprKmacPartialW  = 'd13
   } ispr_e;
 
   typedef logic [$clog2(NFlagGroups)-1:0] flag_group_t;

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -576,6 +576,30 @@ package otbn_pkg;
     logic            shift_acc;
   } mac_bignum_operation_t;
 
+  // States for KMAC error handling
+  // Encoding generated with:
+  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 2 -n 4 \
+  //     -s 573349984 --language=sv
+  //
+  // Hamming distance histogram:
+  //
+  //  0: --
+  //  1: --
+  //  2: --
+  //  3: |||||||||||||||||||| (100.00%)
+  //  4: --
+  //
+  // Minimum Hamming distance: 3
+  // Maximum Hamming distance: 3
+  // Minimum Hamming weight: 2
+  // Maximum Hamming weight: 3
+  //
+  localparam int StateWidth = 4;
+  typedef enum logic [StateWidth-1:0] {
+    StIdle         = 4'b1010,
+    StPendingReady = 4'b1101
+  } kmac_undersized_state_e;
+
   // Encoding generated with:
   // $ ./util/design/sparse-fsm-encode.py -d 3 -m 4 -n 5 \
   //      -s 5799399942 --language=sv

--- a/hw/ip/otbn/rtl/otbn_predecode.sv
+++ b/hw/ip/otbn/rtl/otbn_predecode.sv
@@ -1,4 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192)
+// Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -479,20 +482,28 @@ module otbn_predecode
         CsrFlags, CsrFg0, CsrFg1:           ispr_addr = IsprFlags;
         CsrMod0, CsrMod1, CsrMod2, CsrMod3,
         CsrMod4, CsrMod5, CsrMod6, CsrMod7: ispr_addr = IsprMod;
+        CsrKmacCfg: ispr_addr = IsprKmacCfg;
+        CsrKmacDigestW0, CsrKmacDigestW1, CsrKmacDigestW2, CsrKmacDigestW3, CsrKmacDigestW4,
+        CsrKmacDigestW5, CsrKmacDigestW6, CsrKmacDigestW7: ispr_addr = IsprKmacDigest;
+        CsrKmacPartialW:                    ispr_addr = IsprKmacPartialW;
+        CsrKmacStatus:                      ispr_addr = IsprKmacStatus;
         CsrRnd:                             ispr_addr = IsprRnd;
         CsrUrnd:                            ispr_addr = IsprUrnd;
         default: ;
       endcase
     end else begin
       unique case (wsr_addr)
-        WsrMod:    ispr_addr = IsprMod;
-        WsrRnd:    ispr_addr = IsprRnd;
-        WsrUrnd:   ispr_addr = IsprUrnd;
-        WsrAcc:    ispr_addr = IsprAcc;
-        WsrKeyS0L: ispr_addr = IsprKeyS0L;
-        WsrKeyS0H: ispr_addr = IsprKeyS0H;
-        WsrKeyS1L: ispr_addr = IsprKeyS1L;
-        WsrKeyS1H: ispr_addr = IsprKeyS1H;
+        WsrMod:           ispr_addr = IsprMod;
+        WsrKmacCfg:       ispr_addr = IsprKmacCfg;
+        WsrKmacMsg:       ispr_addr = IsprKmacMsg;
+        WsrKmacDigest:    ispr_addr = IsprKmacDigest;
+        WsrRnd:           ispr_addr = IsprRnd;
+        WsrUrnd:          ispr_addr = IsprUrnd;
+        WsrAcc:           ispr_addr = IsprAcc;
+        WsrKeyS0L:        ispr_addr = IsprKeyS0L;
+        WsrKeyS0H:        ispr_addr = IsprKeyS0H;
+        WsrKeyS1L:        ispr_addr = IsprKeyS1L;
+        WsrKeyS1H:        ispr_addr = IsprKeyS1H;
         default: ;
       endcase
     end

--- a/hw/ip/otbn/rtl/otbn_predecode.sv
+++ b/hw/ip/otbn/rtl/otbn_predecode.sv
@@ -479,31 +479,31 @@ module otbn_predecode
 
     if (csr_addr_sel) begin
       unique case (csr_addr)
-        CsrFlags, CsrFg0, CsrFg1:           ispr_addr = IsprFlags;
         CsrMod0, CsrMod1, CsrMod2, CsrMod3,
         CsrMod4, CsrMod5, CsrMod6, CsrMod7: ispr_addr = IsprMod;
-        CsrKmacCfg: ispr_addr = IsprKmacCfg;
-        CsrKmacDigestW0, CsrKmacDigestW1, CsrKmacDigestW2, CsrKmacDigestW3, CsrKmacDigestW4,
-        CsrKmacDigestW5, CsrKmacDigestW6, CsrKmacDigestW7: ispr_addr = IsprKmacDigest;
+        CsrKmacCfg:                         ispr_addr = IsprKmacCfg;
         CsrKmacPartialW:                    ispr_addr = IsprKmacPartialW;
         CsrKmacStatus:                      ispr_addr = IsprKmacStatus;
+        CsrFlags, CsrFg0, CsrFg1:           ispr_addr = IsprFlags;
         CsrRnd:                             ispr_addr = IsprRnd;
         CsrUrnd:                            ispr_addr = IsprUrnd;
+        CsrKmacDigestW0, CsrKmacDigestW1, CsrKmacDigestW2, CsrKmacDigestW3, CsrKmacDigestW4,
+        CsrKmacDigestW5, CsrKmacDigestW6, CsrKmacDigestW7: ispr_addr = IsprKmacDigest;
         default: ;
       endcase
     end else begin
       unique case (wsr_addr)
-        WsrMod:           ispr_addr = IsprMod;
-        WsrKmacCfg:       ispr_addr = IsprKmacCfg;
-        WsrKmacMsg:       ispr_addr = IsprKmacMsg;
-        WsrKmacDigest:    ispr_addr = IsprKmacDigest;
-        WsrRnd:           ispr_addr = IsprRnd;
-        WsrUrnd:          ispr_addr = IsprUrnd;
-        WsrAcc:           ispr_addr = IsprAcc;
-        WsrKeyS0L:        ispr_addr = IsprKeyS0L;
-        WsrKeyS0H:        ispr_addr = IsprKeyS0H;
-        WsrKeyS1L:        ispr_addr = IsprKeyS1L;
-        WsrKeyS1H:        ispr_addr = IsprKeyS1H;
+        WsrMod:         ispr_addr = IsprMod;
+        WsrKmacCfg:     ispr_addr = IsprKmacCfg;
+        WsrKmacMsg:     ispr_addr = IsprKmacMsg;
+        WsrKmacDigest:  ispr_addr = IsprKmacDigest;
+        WsrRnd:         ispr_addr = IsprRnd;
+        WsrUrnd:        ispr_addr = IsprUrnd;
+        WsrAcc:         ispr_addr = IsprAcc;
+        WsrKeyS0L:      ispr_addr = IsprKeyS0L;
+        WsrKeyS0H:      ispr_addr = IsprKeyS0H;
+        WsrKeyS1L:      ispr_addr = IsprKeyS1L;
+        WsrKeyS1H:      ispr_addr = IsprKeyS1H;
         default: ;
       endcase
     end

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -1,4 +1,7 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192)
+// Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -59,6 +62,7 @@ module otbn_start_stop_control
 
   output logic sec_wipe_acc_urnd_o,
   output logic sec_wipe_mod_urnd_o,
+  output logic sec_wipe_kmac_regs_urnd_o,
   output logic sec_wipe_zero_o,
 
   output logic ispr_init_o,
@@ -163,6 +167,7 @@ module otbn_start_stop_control
     sec_wipe_base_urnd_o      = 1'b0;
     sec_wipe_acc_urnd_o       = 1'b0;
     sec_wipe_mod_urnd_o       = 1'b0;
+    sec_wipe_kmac_regs_urnd_o = 1'b0;
     sec_wipe_zero_o           = 1'b0;
     addr_cnt_inc              = 1'b0;
     secure_wipe_ack_o         = 1'b0;
@@ -296,8 +301,9 @@ module otbn_start_stop_control
         expect_secure_wipe    = 1'b1;
         secure_wipe_running_d = 1'b1;
         // The first two clock cycles are used to write random data to accumulator and modulus.
-        sec_wipe_acc_urnd_o   = (addr_cnt_q == 6'b000000);
-        sec_wipe_mod_urnd_o   = (addr_cnt_q == 6'b000001);
+        sec_wipe_acc_urnd_o       = (addr_cnt_q == 6'b000000);
+        sec_wipe_mod_urnd_o       = (addr_cnt_q == 6'b000001);
+        sec_wipe_kmac_regs_urnd_o = (addr_cnt_q == 6'b000010);
         // Supress writes to the zero register and the call stack.
         sec_wipe_base_o       = (addr_cnt_q > 6'b000001);
         sec_wipe_base_urnd_o  = (addr_cnt_q > 6'b000001);


### PR DESCRIPTION
This PR adds AppIntf RTL support to OTBN in part of the effort to support PQC and OTBN 2.0 plans:

To support ML-KEM and ML-DSA using OTBN, frequent message digest computation using KMAC will be required. To avoid large software interaction between OTBN and KMAC requiring TL-UL access, or an additional MAC unit inside of OTBN, a direct Application Interface is introduced.

Unlike the existing AppIntf connections to LC, ROM, and KeyMgr, OTBN will dynamically set the keccak strength and hashing mode using the first valid word in a message request. The OTBN/KMAC AppIntf is only meant to support SHA3-256/512 and SHAKE-128/256 configurations. OTBN will need to make use of the XOF capabilities of KMAC and SHAKE. A `next` and `hold` signal is introduced to the AppIntf, with `hold` maintaining OTBN/KMAC access and `next` used to shift a new digest from the XOF. These signals are unused in existing AppIntf and tied to `1'b0`.

OTBN was expanded with internal CSR and WSR register mappings used to configure, control, and communicate with the AppIntf and the KMAC. The message size, keccak strength, and sha3 mode are set with the `cfg` register. The `partial_write` register is used as a mask for the `msg` register to allow for a partial write into the MSG FIFO. Reads from the `status` register returns operating conditions, and `digest` will contain the KMAC response. For descriptions and bit fields view `hw/ip/otbn/data/csr.yml` and `hw/ip/otbn/data/wsr.yml`.

To read more on the theory of operation refer to the changes in `hw/ip/otbn/doc/theory_of_operation.md`, `hw/ip/otbn/doc/otbn_intro.md`, and `hw/ip/kmac/doc/theory_of_operation.md`

- Added WSR and CSR registers for communicating with KMAC through the AppIntf
- Added OTBN stall behavior for digest reads when the KMAC response has not yet been generated.
- Added OTBN stall behavior for partial_writes if there is still a pending msg of a different size to be written into the msg FIFO.
- Updated otbnsim model to include a partial write WSR for masking the msg WSR value into the msg FIFO.
- Updated the existing otbnsim model for the msg FIFO inside of the `otbn_bignum_alu.sv` in order to match the flushing and input ready behavior for the byte-masking approach.
- Updated the `hw/ip/otbn/data/wsr.yml` and `hw/ip/otbn/data/csr.yml` to contain new KMAC related registers.

The implementation is built from the basis of work from the Towards ML-KEM and ML-DSA paper from: https://eprint.iacr.org/2024/1192 and Github repo: https://github.com/PQC-OpenTitan/towards-ml-kem-and-ml-dsa-on-opentitan-dev-kmac-only