### PR TITLE
[otbn] Fixed dvsim errors from snippet generators due to increased IMEM/DMEM sizes

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/gens/bad_deep_loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_deep_loop.py
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -48,9 +49,10 @@ class BadDeepLoop(SnippetGen):
         # instruction or points above the top of memory. Rather than doing
         # something clever, we pick the address at random and "re-roll" if it
         # points at a gap in instruction memory. Since bodysize_range[1] is
-        # 4096, giving a maximum address of 16KiB, which happens to equal the
-        # size of IMEM, we know it's going to be possible. Try to pick 50
+        # 4096, it is always possible if IMEM size is 16KiB. Try to pick 50
         # times, which should fail with probability at most 1/4^50 = 1/2^100.
+        # If the IMEM is greater than 16KB, it might not be possible to find a
+        # body size that fits these criteria, so we might fail and return None.
         bodysize_op_type = insn.operands[1].op_type
         bodysize_range = bodysize_op_type.get_op_val_range(pc)
         assert bodysize_range is not None
@@ -64,7 +66,15 @@ class BadDeepLoop(SnippetGen):
                 bodysize = guess
                 break
 
-        assert bodysize is not None
+        # Required return None option to skip generating instruction if a satisfactory
+        # bodysize cannot be found to prevent a build error when running dvsim tests.
+        # When the IMEM is > 16KB the ability to pick a bodysize that points to above
+        # the top of memory is limited to the PC of the insn. If the PC is not within
+        # the bodysize range * 4 of the top of memory the only satisfactory return would
+        # be if the bodysize points to an existing instruction, within a larger IMEM area.
+        if bodysize is None:
+            return None, None
+
         enc_bodysize = bodysize_op_type.op_val_to_enc_val(bodysize, pc)
         assert enc_bodysize is not None
         return (enc_bodysize, pc + 4 * guess)
@@ -121,6 +131,11 @@ class BadDeepLoop(SnippetGen):
 
         enc_bodysize, end_addr = self._pick_bodysize(insn, model.pc, program)
 
+        # Required to prevent assembly gen build error due to IMEM size increase.
+        # Refer to _pick_bodysize for description.
+        if enc_bodysize is None:
+            return None, None
+
         return (ProgInsn(insn, [enc_iters, enc_bodysize], None), end_addr)
 
     def _gen_loop_stack(self,
@@ -143,6 +158,11 @@ class BadDeepLoop(SnippetGen):
             # above)
             prog_insn, _ = self._gen_loop_head(model, program)
 
+            # Required to prevent assembly gen build error due to IMEM size increase.
+            # Refer to _pick_bodysize for description.
+            if prog_insn is None:
+                return (None, None)
+
             # Note that we generate a ProgSnippet, not a LoopSnippet here:
             # while we've got a loop instruction, we happen to know that it
             # will fault, so it's going to behave more like a straight line
@@ -163,6 +183,12 @@ class BadDeepLoop(SnippetGen):
 
         hd_pc = model.pc
         hd_insn, end_addr = self._gen_loop_head(model, program)
+
+        # Required to prevent assembly gen build error due to IMEM size increase.
+        # Refer to _pick_bodysize for description.
+        if hd_insn is None:
+            return (None, None)
+
         program.add_insns(hd_pc, [hd_insn])
         model.update_for_insn(hd_insn)
         model.pc += 4
@@ -187,6 +213,11 @@ class BadDeepLoop(SnippetGen):
             body_snippet = jump_snippet
 
         real_body_snippet, model = self._gen_loop_stack(model, program)
+
+        # Required to prevent assembly gen build error due to IMEM size increase.
+        # Refer to _pick_bodysize for description.
+        if real_body_snippet is None:
+            return (None, None)
 
         if body_snippet is None:
             body_snippet = real_body_snippet
@@ -251,4 +282,10 @@ class BadDeepLoop(SnippetGen):
 
         # At this point, we *should* be able to make the loop unconditionally.
         snippet, model = self._gen_loop_stack(model, program)
+
+        # Required to prevent assembly gen build error due to IMEM size increase.
+        # Refer to _pick_bodysize for description.
+        if snippet is None:
+            return None
+
         return (snippet, model)

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_load_store.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_load_store.py
@@ -1,8 +1,10 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
 import random
+import math
 from typing import Optional
 
 from shared.insn_yaml import Insn, InsnsFile
@@ -215,13 +217,31 @@ class BadLoadStore(SnippetGen):
         tgt_addr = random.randrange(val + min_offset, val + max_offset, 32)
 
         # Check if randomized tgt_addr is in OOB region.
-        if tgt_addr >> 12:
+        exponent = int(math.log(model.dmem_size, 2))
+        if tgt_addr >> exponent:
             bn_imm_val = tgt_addr - val
         # If randomized tgt_addr is not in OOB region, make sure bn_imm_val is
         # big enough. So that the new resulting tgt_addr will definitely
         # be in OOB region.
         else:
             bn_imm_val = tgt_addr + model.dmem_size - val
+            # There is a chance that with DMEM > 16KB that the offset does not take OOB
+            # easiest solution is if known reg val is less than 16,352 we adjust offset
+            # to produce a tgt_addr that is negative. First try with selected register.
+            # Trying to get an OOB address > DMEM SIZE would require an additional insn
+            if (
+                bn_imm_val > max_offset
+                and val < max_offset
+            ):
+                tgt_addr = random.randrange(val + min_offset, -1, 32)
+                bn_imm_val = tgt_addr - val
+            else:
+                # Otherwise we can use known reg 0x0 with value of 0 and negative offset.
+                for idx, u_val in known_regs:
+                    val = u_val - (1 << 32) if u_val >> 31 else u_val
+                    if val < max_offset:
+                        tgt_addr = random.randrange(val + min_offset, -1, 32)
+                        bn_imm_val = tgt_addr - val
 
         # Check if the final target address is in OOB region
         assert bn_imm_val + val < 0 or bn_imm_val + val >= model.dmem_size


### PR DESCRIPTION
This PR fixed oversized immediate values from bad_load_store due to a `DMEM size > 16KB`. If the imm is out of range `-16384 <= imm <= 16352` we first check if the value of the known register is less than the max immediate offset. If so we find a suitable negative offset such that `addr < 0`. Alternatively, if the known register value is `16352 < reg_val < (MEM_SIZE - 16352)` then no negative or positive offset will be out of bounds. We loop through the known registers until we find a register where the immediate can take us out of bounds. This will work 100% of the time since `0x0` is always known with a 0 value.

It also adds error handling for bad_deep_loop to prevent a build failure. If IMEM is greater than 16KB there is a significant chance that the loop does not hit a memory address that has already been written to. It is also impossible for the bodysize to reach the last address in memory, therefore a None path has been added. The current IMEM size is 32KB, and if this is decreased the original behavior will be observed, which has about a `1/2^100` failure rate.