### PR TITLE
[mldsa] Reapply memory optimizations to sign.

### DIFF
--- a/sw/otbn/crypto/mldsa/intt.s
+++ b/sw/otbn/crypto/mldsa/intt.s
@@ -1,4 +1,5 @@
 /* Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors */
+/* Copyright zeroRISC Inc. */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* Modified by Ruben Niederhagen and Hoang Nguyen Hien Pham - authors of */
@@ -33,7 +34,7 @@
  * @param[in]  w31: all-zero
  * @param[out] x10: dmem pointer to result
  *
- * clobbered registers: x4-x30, w0-w23, w30
+ * clobbered registers: x4-x27, w0-w15, w17-w21, w24-w30
  */
 .global intt
 intt:

--- a/sw/otbn/crypto/mldsa/mldsa_sign.s
+++ b/sw/otbn/crypto/mldsa/mldsa_sign.s
@@ -1,4 +1,5 @@
 /* Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors */
+/* Copyright zeroRISC Inc. */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* Modified by Ruben Niederhagen and Hoang Nguyen Hien Pham - authors of */
@@ -180,68 +181,60 @@ crypto_sign_signature_internal:
     #define STACK_TR -96 /* Prev - 16 - 64 */
         #define STACK_MU -96 /* Prev */
     #define STACK_RHO -128 /* Prev - 32 */
-        #define STACK_RND -128 /* Prev */
-    #define STACK_KEY -160 /* Prev - 32 */
-    #define STACK_RHOPRIME  -160 /* Prev */
+    #define STACK_RND -160 /* Prev - 32 */
+    #define STACK_KEY -192 /* Prev - 32 */
+    #define STACK_RHOPRIME -192 /* Prev */
 #if DILITHIUM_MODE == 2
-    #define STACK_T0  -4256 /* Prev - K*1024 */
-    #define STACK_S1  -8352 /* Prev - L*1024 */
-    #define STACK_S2  -12448 /* Prev - K*1024 */
-    #define STACK_MAT -28832 /* Prev - K*L*1024 */
-    #define STACK_Y -32928 /* Prev - K*1024 */
-        #define STACK_H -32928 /* Prev */
-        #define STACK_TMP_POLYVEC -32928 /* Prev */
-    #define STACK_Z -37024 /* Prev - L*1024 */
-    #define STACK_W1 -41120 /* Prev - K*1024 */
-    #define STACK_W0 -45216 /* Prev - K*1024 */
-    #define STACK_CP -46240 /* Prev - 1024 */
-        #define STACK_CTXLEN -46240 /* Prev */
-        #define STACK_CTX -46244 /* Prev - 4 */
-    #define SIGNATURE -48672 /* Prev - ((CRYPTO_BYTES>>5)+1)*1024 */
+    #define STACK_T0  -4288 /* Prev - K*1024 */
+    #define STACK_S1  -8384 /* Prev - L*1024 */
+    #define STACK_S2  -12480 /* Prev - K*1024 */
+    #define STACK_MAT  -13504 /* Prev - 1024 */
+    #define STACK_Y  -17600 /* Prev - K*1024 */
+        #define STACK_H  -17600 /* Prev */
+    #define STACK_Z  -21696 /* Prev - L*1024 */
+    #define STACK_W1  -25792 /* Prev - K*1024 */
+    #define STACK_W0  -29888 /* Prev - K*1024 */
+    #define STACK_CP  -30912 /* Prev - 1024 */
+        #define STACK_CTXLEN  -30912 /* Prev */
+    #define STACK_CTX  -30916 /* Prev - 4 */
+    #define INIT_SP -30944
 
 #elif DILITHIUM_MODE == 3
-    #define STACK_T0  -6304 /* Prev - K*1024 */
-    #define STACK_S1  -11424 /* Prev - L*1024 */
-    #define STACK_S2  -17568 /* Prev - K*1024 */
-    #define STACK_MAT -48288 /* Prev - K*L*1024 */
-    #define STACK_Y -54432 /* Prev - K*1024 */
-        #define STACK_H -54432 /* Prev */
-        #define STACK_TMP_POLYVEC -54432 /* Prev */
-    #define STACK_Z -59552 /* Prev - L*1024 */
-    #define STACK_W1 -65696 /* Prev - K*1024 */
-    #define STACK_W0 -71840 /* Prev - K*1024 */
-    #define STACK_CP -72864 /* Prev - 1024 */
-        #define STACK_CTXLEN -72864 /* Prev */
-        #define STACK_CTX -72868 /* Prev - 4 */
-    #define SIGNATURE -76192 /* Prev - ((CRYPTO_BYTES>>5)+1)*32 */
+    #define STACK_T0  -6336 /* Prev - K*1024 */
+    #define STACK_S1  -11456 /* Prev - L*1024 */
+    #define STACK_S2  -17600 /* Prev - K*1024 */
+    #define STACK_MAT  -18624 /* Prev - 1024 */
+    #define STACK_Y  -24768 /* Prev - K*1024 */
+        #define STACK_H  -24768 /* Prev */
+    #define STACK_Z  -29888 /* Prev - L*1024 */
+    #define STACK_W1  -36032 /* Prev - K*1024 */
+    #define STACK_W0  -42176 /* Prev - K*1024 */
+    #define STACK_CP  -43200 /* Prev - 1024 */
+        #define STACK_CTXLEN  -43200 /* Prev */
+    #define STACK_CTX  -43204 /* Prev - 4 */
+    #define INIT_SP -43232
 
 #elif DILITHIUM_MODE == 5
-    #define STACK_T0  -8352 /* Prev - K*1024 */
-    #define STACK_S1  -15520 /* Prev - L*1024 */
-    #define STACK_S2  -23712 /* Prev - K*1024 */
-    #define STACK_MAT -81056 /* Prev - K*L*1024 */
-    #define STACK_Y -89248 /* Prev - K*1024 ; actually, L is enough but we overlap with TMP */
-        #define STACK_H -89248 /* Prev */
-        #define STACK_TMP_POLYVEC -89248 /* overlap */
-    #define STACK_Z -96416 /* Prev - L*1024 */
-    #define STACK_W1 -104608 /* Prev - K*1024 */
-    #define STACK_W0 -112800 /* Prev - K*1024 */
-    #define STACK_CP -113824 /* Prev - 1024 */
-        #define STACK_CTXLEN -113824 /* Prev */
-        #define STACK_CTX -113828 /* Prev - 4 */
-    #define SIGNATURE -118464 /* Prev - ((CRYPTO_BYTES>>5)+1)*32 */
+    #define STACK_T0  -8384 /* Prev - K*1024 */
+    #define STACK_S1  -15552 /* Prev - L*1024 */
+    #define STACK_S2  -23744 /* Prev - K*1024 */
+    #define STACK_MAT  -24768 /* Prev - 1024 */
+    #define STACK_Y  -32960 /* Prev - K*1024 */
+        #define STACK_H  -32960 /* Prev */
+    #define STACK_Z  -40128 /* Prev - L*1024 */
+    #define STACK_W1  -48320 /* Prev - K*1024 */
+    #define STACK_W0  -56512 /* Prev - K*1024 */
+    #define STACK_CP  -57536 /* Prev - 1024 */
+        #define STACK_CTXLEN  -57536 /* Prev */
+    #define STACK_CTX  -57540 /* Prev - 4 */
+    #define INIT_SP -57568
+
 #endif
     /* Initialize the frame pointer */
     addi fp, sp, 0
 
     /* Reserve space on the stack */
-#if DILITHIUM_MODE == 2
-    li  t0, -48672
-#elif DILITHIUM_MODE == 3
-    li  t0, -76192
-#elif DILITHIUM_MODE == 5
-    li  t0, -118464
-#endif
+    li  t0, INIT_SP
     add sp, sp, t0
 
     /* Store parameters to stack */
@@ -474,23 +467,6 @@ crypto_sign_signature_internal:
 
     /* Finish the SHAKE-256 operation. */
 
-    /* Expand matrix */
-    /* Initialize the nonce */
-    li a2, 0
-
-    li a1, STACK_MAT
-    add a1, fp, a1
-    LOOPI K, 10
-        LOOPI L, 7
-            /* Load parameters */
-            addi a0, fp, STACK_RHO
-            push a2
-            jal  x1, poly_uniform
-            pop a2
-            addi a2, a2, 1
-        addi a2, a2, 256
-        addi a2, a2, -L
-
 #ifdef DILITHIUM_RANDOMIZED_SIGNING
     /* NOTE: Write real randomness to STACK_RND */
 #else
@@ -657,16 +633,52 @@ _rej_crypto_sign_signature_internal:
     /* Load offset for resetting pointer */
     li s0, POLYVECL_BYTES
 
+    /* Initialize the nonce for matrix expansion. This value should be
+         byte(i) || byte(j)
+       for entry A[i][j]. */
+    li a3, 0
+
+    /* Compute A * y, computing the values for A on the fly. */
     .rept K
+        push a0
+        push a2
+        push a3
+        li  a0, STACK_RHO
+        add a0, fp, a0
+        addi a2, a3, 0
+        jal  x1, poly_uniform
+        addi a1, a1, -1024
+        pop a3
+        pop a2
+        pop a0
+        addi a3, a3, 1
         jal  x1, poly_pointwise
+        addi a1, a1, -1024
         addi a2, a2, -1024
         .rept L-1
+            push a0
+            push a2
+            push a3
+            li  a0, STACK_RHO
+            add a0, fp, a0
+            addi a2, a3, 0
+            jal  x1, poly_uniform
+            pop a3
+            pop a2
+            pop a0
+            addi a1, a1, -1024
+            addi a3, a3, 1
             jal  x1, poly_pointwise_acc
+            addi a1, a1, -1024
             addi a2, a2, -1024
         .endr
         /* Reset input vector pointer */
         sub  a0, a0, s0
         addi a2, a2, 1024
+        /* Increment the row index in the nonce by one. */
+        addi a3, a3, 256
+        /* Reset the column index in the nonce to zero. */
+        addi a3, a3, -L
     .endr
 
     /* After poly_pointwise, w16 is still R | Q and MOD is still 2*R | 2*Q */

--- a/sw/otbn/crypto/mldsa/mldsa_sign.s
+++ b/sw/otbn/crypto/mldsa/mldsa_sign.s
@@ -190,23 +190,23 @@ crypto_sign_signature_internal:
     #define STACK_TMP -2240 /* Prev - 1024 */
     #define STACK_CP  -3264 /* Prev - 1024 */
 #if DILITHIUM_MODE == 2
-    #define STACK_W1  -7360 /* Prev - K*1024 */
-    #define STACK_W0  -11456 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -11456 /* Prev */
-    #define STACK_CTX  -11460 /* Prev - 4 */
-    #define INIT_SP -11488
+    #define STACK_W1  -3392 /* Prev - K*32 */
+    #define STACK_W0  -7488 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -7488 /* Prev */
+    #define STACK_CTX  -7492 /* Prev - 4 */
+    #define INIT_SP -7520
 #elif DILITHIUM_MODE == 3
-    #define STACK_W1  -9408 /* Prev - K*1024 */
-    #define STACK_W0  -15552 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -15552 /* Prev */
-    #define STACK_CTX  -15556 /* Prev - 4 */
-    #define INIT_SP -15584
+    #define STACK_W1  -3456 /* Prev - K*32 */
+    #define STACK_W0  -9600 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -9600 /* Prev */
+    #define STACK_CTX  -9604 /* Prev - 4 */
+    #define INIT_SP -9632
 #elif DILITHIUM_MODE == 5
-    #define STACK_W1  -11456 /* Prev - K*1024 */
-    #define STACK_W0  -19648 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -19648 /* Prev */
-    #define STACK_CTX  -19652 /* Prev - 4 */
-    #define INIT_SP -19680
+    #define STACK_W1  -3520 /* Prev - K*32 */
+    #define STACK_W0  -11712 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -11712 /* Prev */
+    #define STACK_CTX  -11716 /* Prev - 4 */
+    #define INIT_SP -11744
 #endif
 
     /* Initialize the frame pointer */
@@ -477,7 +477,7 @@ _rej_crypto_sign_signature_internal:
     /* Matrix-vector multiplication */
 
     /* Get destination pointer. */
-    li s1, STACK_W1
+    li s1, STACK_W0
     add s1, fp, s1
 
     /* Initialize destination to 0. */
@@ -488,7 +488,7 @@ _rej_crypto_sign_signature_internal:
           bn.sid t0, 0(t1++)
         nop
 
-    /* Load the constant for resetting the w1 pointer. */
+    /* Load the constant for resetting the w pointer. */
     li s6, POLYVECK_BYTES
 
     /* Initialize the nonce for matrix expansion. This value should be
@@ -504,7 +504,7 @@ _rej_crypto_sign_signature_internal:
          for j in 0..l-1:
            yj = ntt(y[j])
            for i in 0..k-1:
-             w1[i] += A[i][j] * yj
+             w[i] += A[i][j] * yj
     */
     .rept L
         /* Compute y[j]. */
@@ -536,15 +536,15 @@ _rej_crypto_sign_signature_internal:
             add  a0, fp, a0
             li   a1, STACK_TMP
             add  a1, fp, a1
-            addi a2, s1, 0 /* *W1[i] */
-            /* Add A[i][j] * y[j] to w1[i]. */
+            addi a2, s1, 0 /* *w[i] */
+            /* Add A[i][j] * y[j] to w[i]. */
             jal  x1, poly_pointwise_acc
-            /* Increment the w1 pointer. */
+            /* Increment the w pointer. */
             addi s1, s1, 1024
             /* Increment the row index by 1. */
             addi s4, s4, 256
          .endr
-        /* Reset w1 pointer. */
+        /* Reset w pointer. */
         sub  s1, s1, s6
         /* Increment the column index in the nonce by one. */
         addi s4, s4, 1
@@ -554,8 +554,8 @@ _rej_crypto_sign_signature_internal:
     .endr
 
     bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
-    /* Inverse NTT on w1 */
-    li  a0, STACK_W1
+    /* Inverse NTT on w */
+    li  a0, STACK_W0
     add a0, fp, a0
     la  a1, twiddles_inv
 
@@ -575,34 +575,6 @@ _rej_crypto_sign_signature_internal:
     .endr
     bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
 
-    /* Load source pointers */
-
-    /* Decompose */
-    li   a2, STACK_W1 /* Input */
-    add  a2, fp, a2
-    addi a1, a2, 0    /* Output inplace */
-    li   a0, STACK_W0 /* Output */
-    add  a0, fp, a0
-
-    LOOPI K, 2
-        jal x1, poly_decompose
-        nop
-
-    /* Pack w1 */
-    li  a1, STACK_W1 /* Get *w1 */
-    add a1, fp, a1
-    /* Use an offset of 16 to accomodate for the alignment hack for CTILDE */
-    li  a0, STACK_SIG
-    add a0, fp, a0
-    lw  a0, 0(a0) /* Get *sig */
-#if CTILDEBYTES == 48
-    addi a0, a0, 16
-#endif
-
-    LOOPI K, 2
-        jal x1, polyw1_pack
-        nop
-
     /* Random oracle */
     /* Initialize a SHAKE256 operation. */
     addi  a1, zero, CRHBYTES
@@ -618,25 +590,55 @@ _rej_crypto_sign_signature_internal:
     add a0, fp, a0
     jal x1, keccak_send_message
 
-    /* Send packed w1 to the Keccak core. */
-    /* set packed w1 length to K*POLYW1_PACKEDBYTES */
-    li a1, 0
-    LOOPI K, 1
-        addi a1, a1, POLYW1_PACKEDBYTES
-    /* Use an offset of 16 to accomodate for the alignment hack for CTILDE */
-    li   a0, STACK_SIG
-    add  a0, fp, a0
-    lw   a0, 0(a0) /* get *sig */
-    addi s0, a0, 0 /* save a0 */
+    /* Save some pointers for loop. */
+    li  s0, STACK_W0
+    add s0, fp, s0
+    li  s1, STACK_W1
+    add s1, fp, s1
+    li  s4, STACK_TMP
+    add s4, fp, s4
+
+    /* Get the pointer to the signature (used as tmp buffer for packed w1). */
+    li  s2, STACK_SIG
+    add s2, fp, s2
+    lw  s2, 0(s2) /* Get *sig */
+    addi s3, s2, 0 /* Save *sig. */
 #if CTILDEBYTES == 48
-    addi a0, a0, 16
+    /* Use an offset of 16 to get an aligned buffer (alignment hack for CTILDE). */
+    addi s2, s2, 16
 #endif
-    jal  x1, keccak_send_message
+
+    /* This loop:
+         - decomposes each polynomial w[i] into w0[i] and w1[i]
+         - packs w1[i] and sends it to the Keccak core
+         - records the nonzero high bits of w1[i] for later use
+
+       Afterwards, the w1[i] value can be discarded, so we do not need to keep
+       two w-sized polyvecs in scope at once. */
+    .rept K
+        /* Decompose w and store w0 in-place, w1 in tmp. */
+        addi   a0, s0, 0
+        addi   a1, s4, 0
+        addi   a2, s0, 0
+        jal    x1, poly_decompose
+        /* Pack w1. */
+        addi   a0, s2, 0
+        addi   a1, s4, 0
+        jal    x1, polyw1_pack
+        /* Send packed w1 to the Keccak core. */
+        addi   a0, s2, 0
+        li     a1, POLYW1_PACKEDBYTES
+        jal    x1, keccak_send_message
+        /* Calculate the coefficients of w1 that are nonzero mod q, and store them. */
+        addi   a0, s4, 0
+        jal    x1, poly_nonzero_encode
+        bn.sid x0, 0(s1++)
+        /* Increment w pointer. */
+        addi s0, s0, 1024
+    .endr
 
     /* Setup WDR */
     li t1, 8
-    /* Restore a0. */
-    addi a0, s0, 0
 
     /* Read first 32 bytes of digest. */
     bn.wsrr w8, 0xA
@@ -647,32 +649,32 @@ _rej_crypto_sign_signature_internal:
 #if CTILDEBYTES == 32
     /* Store first 32 bytes into temp buffer and signature. */
     bn.sid  t1, 0(t0)
-    bn.sid  t1, 0(a0)
+    bn.sid  t1, 0(s3)
 #elif CTILDEBYTES == 48
     /* Store first 32 bytes into temp buffer and (unaligned) signature. */
     bn.sid  t1, 0(t0)
     LOOPI 8, 4
         lw t2, 0(t0)
-        sw t2, 0(a0)
+        sw t2, 0(s3)
         addi t0, t0, 4
-        addi a0, a0, 4
+        addi s3, s3, 4
 
     /* Read 32 more bytes and store 16 of them. */
     bn.wsrr w8, 0xA
     bn.sid  t1, 0(t0)
     LOOPI 4, 4
         lw t2, 0(t0)
-        sw t2, 0(a0)
+        sw t2, 0(s3)
         addi t0, t0, 4
-        addi a0, a0, 4
+        addi s3, s3, 4
 #elif CTILDEBYTES == 64
     /* Store first 32 bytes into temp buffer and signature. */
     bn.sid  t1, 0(t0)
-    bn.sid  t1, 0(a0)
+    bn.sid  t1, 0(s3)
     /* Store 32 more bytes (both places). */
     bn.wsrr w8, 0xA
     bn.sid  t1, 32(t0)
-    bn.sid  t1, 32(a0)
+    bn.sid  t1, 32(s3)
 #endif
 
     /* Finish the SHAKE-256 operation. */
@@ -972,10 +974,10 @@ _rej_crypto_sign_signature_internal:
         bne  a0, zero, _rej_crypto_sign_signature_internal
 
         /* h[i] = make_hint(w0[i], w1[i]) */
-        addi a0, s1, 0
-        addi a1, s3, 0
-        addi a2, s5, 0
-        jal x1, poly_make_hint
+        addi   a0, s1, 0
+        addi   a1, s3, 0
+        bn.lid x0, 0(s5++)
+        jal    x1, poly_make_hint
 
         /* Update the coefficient sum accumulator (saving previous value). */
         add  a2, s4, 0
@@ -997,8 +999,6 @@ _rej_crypto_sign_signature_internal:
         addi s6, s6, 1
         /* Update pointer into w0. */
         addi s3, s3, 1024
-        /* Update pointer into w1. */
-        addi s5, s5, 1024
     .endr
 
     /* Return success and signature length */

--- a/sw/otbn/crypto/mldsa/mldsa_sign.s
+++ b/sw/otbn/crypto/mldsa/mldsa_sign.s
@@ -190,14 +190,14 @@ crypto_sign_signature_internal:
     #define STACK_S2  -12480 /* Prev - K*1024 */
     #define STACK_MAT  -13504 /* Prev - 1024 */
       #define STACK_CP  -13504 /* Prev */
-    #define STACK_Y  -17600 /* Prev - K*1024 */
-        #define STACK_H  -17600 /* Prev */
-    #define STACK_Z  -21696 /* Prev - L*1024 */
-    #define STACK_W1  -25792 /* Prev - K*1024 */
-    #define STACK_W0  -29888 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -29888 /* Prev */
-    #define STACK_CTX  -29892 /* Prev - 4 */
-    #define INIT_SP -29920
+    #define STACK_Y  -14528 /* Prev - 1024 */
+    #define STACK_Z  -18624 /* Prev - L*1024 */
+    #define STACK_W1  -22720 /* Prev - K*1024 */
+        #define STACK_H  -22720 /* Prev */
+    #define STACK_W0  -26816 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -26816 /* Prev */
+    #define STACK_CTX  -26820 /* Prev - 4 */
+    #define INIT_SP -26848
 
 #elif DILITHIUM_MODE == 3
     #define STACK_T0  -6336 /* Prev - K*1024 */
@@ -205,14 +205,14 @@ crypto_sign_signature_internal:
     #define STACK_S2  -17600 /* Prev - K*1024 */
     #define STACK_MAT  -18624 /* Prev - 1024 */
       #define STACK_CP  -18624 /* Prev */
-    #define STACK_Y  -24768 /* Prev - K*1024 */
-        #define STACK_H  -24768 /* Prev */
-    #define STACK_Z  -29888 /* Prev - L*1024 */
-    #define STACK_W1  -36032 /* Prev - K*1024 */
-    #define STACK_W0  -42176 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -42176 /* Prev */
-    #define STACK_CTX  -42180 /* Prev - 4 */
-    #define INIT_SP -42208
+    #define STACK_Y  -19648 /* Prev - 1024 */
+    #define STACK_Z  -24768 /* Prev - L*1024 */
+    #define STACK_W1  -30912 /* Prev - K*1024 */
+        #define STACK_H  -30912 /* Prev */
+    #define STACK_W0  -37056 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -37056 /* Prev */
+    #define STACK_CTX  -37060 /* Prev - 4 */
+    #define INIT_SP -37088
 
 #elif DILITHIUM_MODE == 5
     #define STACK_T0  -8384 /* Prev - K*1024 */
@@ -220,14 +220,14 @@ crypto_sign_signature_internal:
     #define STACK_S2  -23744 /* Prev - K*1024 */
     #define STACK_MAT  -24768 /* Prev - 1024 */
       #define STACK_CP  -24768 /* Prev */
-    #define STACK_Y  -32960 /* Prev - K*1024 */
-        #define STACK_H  -32960 /* Prev */
-    #define STACK_Z  -40128 /* Prev - L*1024 */
-    #define STACK_W1  -48320 /* Prev - K*1024 */
-    #define STACK_W0  -56512 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -56512 /* Prev */
-    #define STACK_CTX  -56516 /* Prev - 4 */
-    #define INIT_SP -56544
+    #define STACK_Y  -25792 /* Prev - 1024 */
+    #define STACK_Z  -32960 /* Prev - L*1024 */
+    #define STACK_W1  -41152 /* Prev - K*1024 */
+        #define STACK_H  -41152 /* Prev */
+    #define STACK_W0  -49344 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -49344 /* Prev */
+    #define STACK_CTX  -49348 /* Prev - 4 */
+    #define INIT_SP -49376
 
 #endif
     /* Initialize the frame pointer */
@@ -581,105 +581,89 @@ crypto_sign_signature_internal:
     li s11, 0 /* nonce */
 
 _rej_crypto_sign_signature_internal:
-    /* Uniform GAMMA1 */
-    li  a1, STACK_RHOPRIME
-    add a1, fp, a1
-
-    li  a0, STACK_Y
-    add a0, fp, a0
-
-    addi a2, s11, 0 /* Compute nonce */
-    la   a3, gamma1_vec_const
-
-    LOOPI L, 3
-        jal  x1, poly_uniform_gamma_1
-        addi a0, a0, 1024
-        addi a2, a2, 1 /* a2 should be preserved after execution */
-
-    addi s11, s11, L
-
-    bn.wsrw  0x0, mod_x2 /* MOD = 2*R | 2*Q */
-    /* NTT(Y) -> Z */
-    li  a0, STACK_Y
-    add a0, fp, a0 /* in */
-    li  a2, STACK_Z
-    add a2, fp, a2 /* out */
-    la  a1, twiddles_fwd
-
-  .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-     push \reg
-  .endr
-
-    LOOPI L, 2
-        jal x1, ntt
-        addi a1, a1, -1024
-
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-      pop \reg
-    .endr
-
-    /* After NTT, w16 is still R | Q and MOD is still 2*R | 2*Q */
     /* Matrix-vector multiplication */
 
-    /* Load source pointers */
-    li  a0, STACK_Z
-    add a0, fp, a0
-    li  a1, STACK_MAT
-    add a1, fp, a1
+    /* Save some stack offsets. */
+    li s0, STACK_Y
+    add s0, fp, s0
+    li s1, STACK_W1
+    add s1, fp, s1
+    li s2, STACK_MAT
+    add s2, fp, s2
+    li s3, STACK_RHOPRIME
+    add s3, fp, s3
+    li s5, STACK_RHO
+    add s5, fp, s5
 
-    /* Load destination pointer */
-    li  a2, STACK_W1
-    add a2, fp, a2
+    /* Initialize destination to 0. */
+    li t0, 31
+    addi a3, s1, 0
+    LOOPI K, 3
+        LOOPI 32, 1
+          bn.sid t0, 0(a3++)
+        nop
 
-    /* Load offset for resetting pointer */
-    li s0, POLYVECL_BYTES
+    /* Load the constant for resetting the w1 pointer. */
+    li s6, POLYVECK_BYTES
 
     /* Initialize the nonce for matrix expansion. This value should be
          byte(i) || byte(j)
        for entry A[i][j]. */
-    li a3, 0
+    li s4, 0
 
-    /* Compute A * y, computing the values for A on the fly. */
-    .rept K
-        push a0
-        push a2
-        push a3
-        li  a0, STACK_RHO
-        add a0, fp, a0
-        addi a2, a3, 0
-        jal  x1, poly_uniform
-        addi a1, a1, -1024
-        pop a3
-        pop a2
-        pop a0
-        addi a3, a3, 1
-        jal  x1, poly_pointwise
-        addi a1, a1, -1024
-        addi a2, a2, -1024
-        .rept L-1
-            push a0
-            push a2
-            push a3
-            li  a0, STACK_RHO
-            add a0, fp, a0
-            addi a2, a3, 0
+    /* Compute A * y, computing the values for A and y on the fly.
+
+       We compute column-wise so that we genearate elements of y only once; in
+       pseudocode, this computation does:
+
+         for j in 0..l-1:
+           yj = ntt(y[j])
+           for i in 0..k-1:
+             w1[i] += A[i][j] * yj
+    */
+    .rept L
+        /* Compute y[j], storing temporarily in the matrix poly buffer. */
+        li   a0, STACK_MAT
+        add  a0, fp, a0
+        li   a1, STACK_RHOPRIME
+        add  a1, fp, a1
+        addi a2, s11, 0 /* y sampling nonce */
+        la   a3, gamma1_vec_const
+        jal  x1, poly_uniform_gamma_1
+        addi s11, a2, 1 /* a2 should be preserved after execution */
+        /* Compute ntt(y[j]). */
+        li   a0, STACK_MAT
+        add  a0, fp, a0
+        la  a1, twiddles_fwd
+        li   a2, STACK_Y
+        add  a2, fp, a2
+        jal x1, ntt
+        .rept K
+            /* Compute A[i][j]. */
+            li   a0, STACK_RHO
+            add  a0, fp, a0
+            li   a1, STACK_MAT
+            add  a1, fp, a1
+            addi a2, s4, 0 /* matrix nonce */
             jal  x1, poly_uniform
-            pop a3
-            pop a2
-            pop a0
-            addi a1, a1, -1024
-            addi a3, a3, 1
+            li   a0, STACK_Y
+            add  a0, fp, a0
+            li   a1, STACK_MAT
+            add  a1, fp, a1
+            addi a2, s1, 0 /* *W1[i] */
+            /* Add A[i][j] * y[j] to w1[i]. */
             jal  x1, poly_pointwise_acc
-            addi a1, a1, -1024
-            addi a2, a2, -1024
-        .endr
-        /* Reset input vector pointer */
-        sub  a0, a0, s0
-        addi a2, a2, 1024
-        /* Increment the row index in the nonce by one. */
-        addi a3, a3, 256
-        /* Reset the column index in the nonce to zero. */
-        addi a3, a3, -L
+            /* Increment the w1 pointer. */
+            addi s1, s1, 1024
+            /* Increment the row index by 1. */
+            addi s4, s4, 256
+         .endr
+        /* Reset w1 pointer. */
+        sub  s1, s1, s6
+        /* Increment the column index in the nonce by one. */
+        addi s4, s4, 1
+        /* Reset the row index in the nonce to zero. */
+        andi s4, s4, 255
     .endr
 
     /* After poly_pointwise, w16 is still R | Q and MOD is still 2*R | 2*Q */
@@ -892,17 +876,33 @@ _rej_crypto_sign_signature_internal:
         pop \reg
     .endr
 
-    /* z = z + y */
-    li  a0, STACK_Z
-    add a0, fp, a0
-    li  a1, STACK_Y
-    add a1, fp, a1
-    li  a2, STACK_Z
-    add a2, fp, a2
+    /* Add y to z, computing values of y on the fly. */
+    addi s11, s11, -L /* reset y nonce */
+    la   a3, gamma1_vec_const
 
-    LOOPI L, 2
+    /* Initialize pointers to y and z. */
+    li  a0, STACK_Y
+    add a0, fp, a0
+    li  a1, STACK_Z
+    add a1, fp, a1
+
+    /* Store the stack offset to avoid using li within a loop. */
+    li  s0, STACK_RHOPRIME
+
+    LOOPI L, 9
+        /* Save the z pointer. */
+        addi s1, a1, 0
+        /* Sample the next value of y. */
+        add a1, fp, s0
+        addi a2, s11, 0
+        jal  x1, poly_uniform_gamma_1
+        addi s11, a2, 1 /* a2 should be preserved after execution */
+        /* z[i] += y[i] */
+        addi a1, s1, 0
+        addi a2, s1, 0
         jal x1, poly_add
-        nop
+        /* Reset the pointer to the buffer for y[i]. */
+        addi a0, a0, -1024
 
     /* reduce32(z) to move to mod^{+-} for bound check */
     li  a0, STACK_Z

--- a/sw/otbn/crypto/mldsa/mldsa_sign.s
+++ b/sw/otbn/crypto/mldsa/mldsa_sign.s
@@ -184,49 +184,31 @@ crypto_sign_signature_internal:
     #define STACK_RND -160 /* Prev - 32 */
     #define STACK_KEY -192 /* Prev - 32 */
       #define STACK_RHOPRIME -192 /* Prev */
+    #define STACK_Y   -1216 /* Prev - 1024 */
+        #define STACK_S1  -1216 /* Prev */
+        #define STACK_H   -1216 /* Prev */
+    #define STACK_TMP -2240 /* Prev - 1024 */
+    #define STACK_CP  -3264 /* Prev - 1024 */
 #if DILITHIUM_MODE == 2
-    #define STACK_T0  -4288 /* Prev - K*1024 */
-    #define STACK_S1  -8384 /* Prev - L*1024 */
-    #define STACK_S2  -12480 /* Prev - K*1024 */
-    #define STACK_CP  -13504 /* Prev - 1024 */
-    #define STACK_Y  -14528 /* Prev - 1024 */
-    #define STACK_Z  -18624 /* Prev - L*1024 */
-    #define STACK_W1  -22720 /* Prev - K*1024 */
-        #define STACK_H  -22720 /* Prev */
-    #define STACK_W0  -26816 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -26816 /* Prev */
-    #define STACK_CTX  -26820 /* Prev - 4 */
-    #define INIT_SP -26848
-
+    #define STACK_W1  -7360 /* Prev - K*1024 */
+    #define STACK_W0  -11456 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -11456 /* Prev */
+    #define STACK_CTX  -11460 /* Prev - 4 */
+    #define INIT_SP -11488
 #elif DILITHIUM_MODE == 3
-    #define STACK_T0  -6336 /* Prev - K*1024 */
-    #define STACK_S1  -11456 /* Prev - L*1024 */
-    #define STACK_S2  -17600 /* Prev - K*1024 */
-    #define STACK_CP  -18624 /* Prev - 1024 */
-    #define STACK_Y  -19648 /* Prev - 1024 */
-    #define STACK_Z  -24768 /* Prev - L*1024 */
-    #define STACK_W1  -30912 /* Prev - K*1024 */
-        #define STACK_H  -30912 /* Prev */
-    #define STACK_W0  -37056 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -37056 /* Prev */
-    #define STACK_CTX  -37060 /* Prev - 4 */
-    #define INIT_SP -37088
-
+    #define STACK_W1  -9408 /* Prev - K*1024 */
+    #define STACK_W0  -15552 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -15552 /* Prev */
+    #define STACK_CTX  -15556 /* Prev - 4 */
+    #define INIT_SP -15584
 #elif DILITHIUM_MODE == 5
-    #define STACK_T0  -8384 /* Prev - K*1024 */
-    #define STACK_S1  -15552 /* Prev - L*1024 */
-    #define STACK_S2  -23744 /* Prev - K*1024 */
-    #define STACK_CP  -24768 /* Prev - 1024 */
-    #define STACK_Y  -25792 /* Prev - 1024 */
-    #define STACK_Z  -32960 /* Prev - L*1024 */
-    #define STACK_W1  -41152 /* Prev - K*1024 */
-        #define STACK_H  -41152 /* Prev */
-    #define STACK_W0  -49344 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -49344 /* Prev */
-    #define STACK_CTX  -49348 /* Prev - 4 */
-    #define INIT_SP -49376
-
+    #define STACK_W1  -11456 /* Prev - K*1024 */
+    #define STACK_W0  -19648 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -19648 /* Prev */
+    #define STACK_CTX  -19652 /* Prev - 4 */
+    #define INIT_SP -19680
 #endif
+
     /* Initialize the frame pointer */
     addi fp, sp, 0
 
@@ -285,35 +267,6 @@ crypto_sign_signature_internal:
     bn.sid t0, 32(t1)
 
 
-    /* Unpack s1 */
-    /* Load pointer to s1 */
-    li   a0, STACK_S1
-    add  a0, fp, a0
-    /* Load pointer to packed s1 */
-    addi a1, a3, 0
-
-    LOOPI L, 2
-        jal x1, polyeta_unpack
-        nop
-
-    /* Unpack s2 */
-    /* Load pointer to s2 */
-    li  a0, STACK_S2
-    add a0, fp, a0
-
-    LOOPI K, 2
-        jal x1, polyeta_unpack
-        nop
-
-    /* Unpack t0 */
-    /* Load pointer to t0 */
-    li  a0, STACK_T0
-    add a0, fp, a0
-
-    LOOPI K, 2
-        jal x1, polyt0_unpack
-        nop
-
     /* CRH(tr, msg) */
 
     /* Initialize a SHAKE256 operation. */
@@ -346,7 +299,7 @@ crypto_sign_signature_internal:
     li t2, STACK_CTXLEN
     add a0, fp, t2
     lw t2, 0(a0) /* t2 <= ctxlen */
-    li t3, STACK_Z /* Re-use Z buffer for absorbing ctxlen and ctx */
+    li t3, STACK_TMP /* Use temporary buffer for absorbing ctxlen and ctx */
     add t3, fp, t3
 
     /* Note: Add support for non-4B multiple ctxlen */
@@ -446,7 +399,7 @@ crypto_sign_signature_internal:
     /* a1 still contains length but includes TRBYTES */
     addi a1, a1, -TRBYTES
 
-    li t3, STACK_Z /* Re-use Z buffer for absorbing ctxlen and ctx */
+    li t3, STACK_TMP /* Use temporary buffer for absorbing ctxlen and ctx */
     add a0, fp, t3
 
     jal x1, keccak_send_message
@@ -518,63 +471,6 @@ crypto_sign_signature_internal:
     bn.wsrr   w16, 0x0 /* w16 = MOD = R | Q */
     bn.shv.8S mod_x2, w16 << 1 /* mod_x2 = 2*R | 2*Q */
 
-    /* NTT(s1) */
-    li   a0, STACK_S1
-    add  a0, fp, a0
-    addi a2, a0, 0 /* Inplace */
-    la   a1, twiddles_fwd
-
-    .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-       push \reg
-    .endr
-
-    bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
-    LOOPI L, 2
-        jal x1, ntt
-        addi a1, a1, -1024 /* Reset twiddle pointer */
-
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-        pop \reg
-    .endr
-
-    /* After NTT(s1), w16 is still R | Q and MOD is still 2*R | 2*Q */
-    /* NTT(s2) */
-    li   a0, STACK_S2
-    add  a0, fp, a0
-    addi a2, a0, 0 /* inplace */
-
-    .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-       push \reg
-    .endr
-
-    LOOPI K, 2
-      jal  x1, ntt
-      addi a1, a1, -1024 /* Reset twiddle pointer */
-
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-        pop \reg
-    .endr
-
-    /* After NTT(s2), w16 is still R | Q and MOD is still 2*R | 2*Q */
-    /* NTT(t0) */
-    li   a0, STACK_T0
-    add  a0, fp, a0
-    addi a2, a0, 0 /* Inplace */
-
-    .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-       push \reg
-    .endr
-
-    LOOPI K, 2
-        jal x1, ntt
-        addi a1, a1, -1024 /* Reset twiddle pointer */
-
-    bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
-
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-        pop \reg
-    .endr
-
     li s11, 0 /* nonce */
 
 _rej_crypto_sign_signature_internal:
@@ -620,6 +516,7 @@ _rej_crypto_sign_signature_internal:
         la   a3, gamma1_vec_const
         jal  x1, poly_uniform_gamma_1
         addi s11, a2, 1 /* a2 should be preserved after execution */
+        bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
         /* Compute ntt(y[j]). */
         li   a0, STACK_Y
         add  a0, fp, a0
@@ -631,13 +528,13 @@ _rej_crypto_sign_signature_internal:
             /* Compute A[i][j]. */
             li   a0, STACK_RHO
             add  a0, fp, a0
-            li   a1, STACK_Z
+            li   a1, STACK_TMP
             add  a1, fp, a1
             addi a2, s4, 0 /* matrix nonce */
             jal  x1, poly_uniform
             li   a0, STACK_Y
             add  a0, fp, a0
-            li   a1, STACK_Z
+            li   a1, STACK_TMP
             add  a1, fp, a1
             addi a2, s1, 0 /* *W1[i] */
             /* Add A[i][j] * y[j] to w1[i]. */
@@ -653,9 +550,10 @@ _rej_crypto_sign_signature_internal:
         addi s4, s4, 1
         /* Reset the row index in the nonce to zero. */
         andi s4, s4, 255
+        bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
     .endr
 
-    /* After poly_pointwise, w16 is still R | Q and MOD is still 2*R | 2*Q */
+    bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
     /* Inverse NTT on w1 */
     li  a0, STACK_W1
     add a0, fp, a0
@@ -671,11 +569,11 @@ _rej_crypto_sign_signature_internal:
         addi a1, a1, -960
         /* Go to next input polynomial */
         addi a0, a0, 1024
-    bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
 
     .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
         pop \reg
     .endr
+    bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
 
     /* Load source pointers */
 
@@ -743,9 +641,8 @@ _rej_crypto_sign_signature_internal:
     /* Read first 32 bytes of digest. */
     bn.wsrr w8, 0xA
 
-    /* Get temp buffer */
     /* Get always-aligned temporary buffer. */
-    li   t0, STACK_CP
+    li   t0, STACK_TMP
     add  t0, fp, t0
 #if CTILDEBYTES == 32
     /* Store first 32 bytes into temp buffer and signature. */
@@ -781,371 +678,328 @@ _rej_crypto_sign_signature_internal:
     /* Finish the SHAKE-256 operation. */
 
     /* Challenge */
-    /* CTILDE was temporarily stored in STACK_CP. Re-use here because it is aligned,
+    /* CTILDE was temporarily stored in STACK_TMP. Re-use here because it is aligned,
        for CTILDEBYTES = 48 as well */
-    li   a1, STACK_CP
-    add  a1, fp, a1
     li   a0, STACK_CP
     add  a0, fp, a0
+    li   a1, STACK_TMP
+    add  a1, fp, a1
     jal  x1, poly_challenge
 
     bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
+
     /* NTT(cp) */
     li   a0, STACK_CP
     add  a0, fp, a0 /* Input */
     addi a2, a0, 0  /* Output inplace */
     la   a1, twiddles_fwd
+    jal  x1, ntt
 
-    .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-        push \reg
-    .endr
-
-    jal x1, ntt /* Only one polynomial */
-
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-        pop \reg
-    .endr
-
-    /* After NTT(cp), w16 is still R | Q and MOD is still 2*R | 2*Q */
-    /* z = cp * s1 */
-    li  a0, STACK_CP
-    add a0, fp, a0
-    li  a1, STACK_S1
-    add a1, fp, a1
-    li  a2, STACK_Z
-    add a2, fp, a2
-
-    LOOPI L, 2
-        jal  x1, poly_pointwise
-        addi a0, a0, -1024
-
-    /* After poly_pointwise, w16 is still R | Q and MOD is still 2*R | 2*Q */
-    /* Inverse NTT on z */
-    li  a0, STACK_Z
-    add a0, fp, a0
-    la  a1, twiddles_inv
-
-    .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-        push \reg
-    .endr
-
-    LOOPI L, 3
-        jal  x1, intt
-        /* Reset the twiddle pointer */
-        addi a1, a1, -960
-        /* Go to next input polynomial */
-        addi a0, a0, 1024
     bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
 
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-        pop \reg
-    .endr
+    /* Load pointer to packed s1 */
+    li   s0, STACK_SK
+    add  s0, fp, s0
+    lw   s0, 0(s0)
+    addi s0, s0, 128
 
-    /* Add y to z, computing values of y on the fly. */
-    addi s11, s11, -L /* reset y nonce */
-    la   a3, gamma1_vec_const
+    /* Reset the nonce for y and set up a constant for poly_uniform_gamma1. */
+    addi s8, s11, -L
 
-    /* Initialize pointers to y and z. */
-    li  a0, STACK_Y
-    add a0, fp, a0
-    li  a1, STACK_Z
-    add a1, fp, a1
+    /* Save some stack pointers. */
+    li   s1, STACK_S1
+    add  s1, fp, s1
+    li   s2, STACK_TMP
+    add  s2, fp, s2
+    li   s3, STACK_RHOPRIME
+    add  s3, fp, s3
+    li   s7, STACK_CP
+    add  s7, fp, s7
+    li   s9, STACK_SIG
+    add  s9, fp, s9
+    lw   s9, 0(s9)
+    addi s9, s9, CTILDEBYTES /* c is already packed */
+    la   s10, gamma1_vec_const
 
-    /* Store the stack offset to avoid using li within a loop. */
-    li  s0, STACK_RHOPRIME
-
-    LOOPI L, 9
-        /* Save the z pointer. */
-        addi s1, a1, 0
-        /* Sample the next value of y. */
-        add a1, fp, s0
-        addi a2, s11, 0
-        jal  x1, poly_uniform_gamma_1
-        addi s11, a2, 1 /* a2 should be preserved after execution */
-        /* z[i] += y[i] */
-        addi a1, s1, 0
-        addi a2, s1, 0
-        jal x1, poly_add
-        /* Reset the pointer to the buffer for y[i]. */
-        addi a0, a0, -1024
-
-    /* reduce32(z) to move to mod^{+-} for bound check */
-    li  a0, STACK_Z
-    add a0, fp, a0
-    li  a1, STACK_Z
-    add a1, fp, a1
-
-    LOOPI L, 2
-        jal x1, poly_reduce32
-        nop
-
-    /* chknorm */
-    li  t0, GAMMA1
-    li  t1, BETA
-    sub a1, t0, t1
-    li  s0, STACK_Z
-    add s0, fp, s0
-
-    /* Cannot use hardware loop due to branch to _rej_crypto_sign_signature_internal */
+    /* This loop computes z = (cp * s1) = y one element at a time, and does
+       rejection sampling on each element before packing it into the signature.
+       Cannot easily be a hardware loop because of the branch to
+       _rej_crypto_sign_signature_internal. */
     .rept L
-        addi a0, s0, 0
-        jal x1, poly_chknorm
-        addi s0, s0, 1024
+        /* Unpack the next polynomial from s1. */
+        addi a0, s1, 0
+        addi a1, s0, 0
+        jal x1, polyeta_unpack
+        /* Update the packed s1 pointer. */
+        addi s0, a1, 0
 
-        /* Reject */
-        bne a0, zero, _rej_crypto_sign_signature_internal
-    .endr
+        bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
 
-    bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
-    /* h = cp * s2 */
-    li  a0, STACK_CP
-    add a0, fp, a0
-    li  a1, STACK_S2
-    add a1, fp, a1
-    li  a2, STACK_H
-    add a2, fp, a2
-
-    LOOPI K, 2
+        /* Compute ntt(s1). */
+        addi a0, s1, 0
+        la   a1, twiddles_fwd
+        addi a2, s1, 0
+        jal x1, ntt
+        /* z = cp * s1 */
+        addi a0, s1, 0
+        addi a1, s7, 0
+        addi a2, s2, 0
         jal  x1, poly_pointwise
-        addi a0, a0, -1024
+        /* After poly_pointwise, w16 is still R | Q and MOD is still 2*R | 2*Q */
 
-    /* After poly_pointwise, w16 is still R | Q and MOD is still 2*R | 2*Q */
-    /* Inverse NTT on h */
-    li  a0, STACK_H
-    add a0, fp, a0
-    la  a1, twiddles_inv
+        /* Inverse NTT on z */
+        addi a0, s2, 0
+        la  a1, twiddles_inv
+        jal x1, intt
 
-    .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-        push \reg
-    .endr
+        bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
 
-    LOOPI K, 3
-        jal  x1, intt
-        /* Reset the twiddle pointer */
-        addi a1, a1, -960
-        /* Go to next input polynomial */
-        addi a0, a0, 1024
-    bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
+        /* Sample the next value of y and reuse s1 buffer to store it. */
+        addi a0, s1, 0
+        addi a1, s3, 0
+        addi a2, s8, 0
+        addi a3, s10, 0
+        jal  x1, poly_uniform_gamma_1
 
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-        pop \reg
-    .endr
+        /* Update the nonce for y. */
+        addi s8, a2, 1
 
-    /* w0 = w0 + h */
-    li     x4, 0
-    li     t1, 1
-    li     a0, STACK_W0
-    add    a0, fp, a0
-    la     t0, modulus
-    bn.lid t1, 0(t0)
-    LOOPI K, 6
-        LOOPI 32, 4
-            bn.lid      x4, 0(a0)
-            bn.addv.8S  w0, w0, w1
-            bn.addvm.8S w0, bn0, w0
-            bn.sid      x4, 0(a0++)
-        NOP
-
-    li  a0, STACK_W0
-    add a0, fp, a0
-    li  a1, STACK_H
-    add a1, fp, a1
-    li  a2, STACK_W0
-    add a2, fp, a2
-
-    LOOPI K, 2
-        jal x1, poly_sub
-        nop
-
-    /* reduce32(z) to move to mod^{+-} for bound check */
-    li  a0, STACK_W0
-    add a0, fp, a0
-    li  a1, STACK_W0
-    add a1, fp, a1
-
-    LOOPI K, 2
-        jal x1, poly_reduce32
-        nop
-
-    /* chknorm */
-    li  t0, GAMMA2
-    li  t1, BETA
-    sub a1, t0, t1
-    li  s0, STACK_W0
-    add s0, fp, s0
-
-    /* Cannot use hardware loop due to branch to _rej_crypto_sign_signature_internal */
-    .rept K
-        addi a0, s0, 0
-        jal  x1, poly_chknorm
-        /* reject */
-        bne  a0, zero, _rej_crypto_sign_signature_internal
-        addi s0, s0, 1024
-    .endr
-
-    bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
-    /* h = cp * t0 */
-    li  a0, STACK_CP
-    add a0, fp, a0
-    li  a1, STACK_T0
-    add a1, fp, a1
-    li  a2, STACK_H
-    add a2, fp, a2
-
-    LOOPI K, 2
-        jal  x1, poly_pointwise
-        addi a0, a0, -1024
-
-    /* After poly_pointwise, w16 is still R | Q and MOD is still 2*R | 2*Q */
-    /* Inverse NTT on h */
-    li  a0, STACK_H
-    add a0, fp, a0
-    la  a1, twiddles_inv
-
-    .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-        push \reg
-    .endr
-
-    LOOPI K, 3
-        jal  x1, intt
-        /* Reset the twiddle pointer */
-        addi a1, a1, -960
-        /* Go to next input polynomial */
-        addi a0, a0, 1024
-    bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
-
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-        pop \reg
-    .endr
-
-    /* w0 = w0 + h */
-    li     x4, 0
-    li     t1, 1
-    li     a0, STACK_W0
-    add    a0, fp, a0
-    la     t0, modulus
-    bn.lid t1, 0(t0)
-    LOOPI K, 6
-        LOOPI 32, 4
-            bn.lid      x4, 0(a0)
-            bn.addv.8S  w0, w0, w1
-            bn.addvm.8S w0, bn0, w0
-            bn.sid      x4, 0(a0++)
-        NOP
-
-    li  a0, STACK_W0
-    add a0, fp, a0
-    li  a1, STACK_H
-    add a1, fp, a1
-    li  a2, STACK_W0
-    add a2, fp, a2
-
-    LOOPI K, 2
+        /* z[i] += y[i] */
+        addi a0, s1, 0
+        addi a1, s2, 0
+        addi a2, s2, 0
         jal x1, poly_add
-        nop
 
-    /* reduce32(z) to move to mod^{+-} for bound check */
-    li  a0, STACK_H
-    add a0, fp, a0
-    li  a1, STACK_H
-    add a1, fp, a1
-
-    LOOPI K, 2
+        /* reduce32(z) to move to mod^{+-} for bound check */
+        addi a0, s2, 0
+        addi a1, s2, 0
         jal x1, poly_reduce32
-        nop
 
-    /* chknorm */
-    li  a1, GAMMA2
-    li  s0, STACK_H
-    add s0, fp, s0
+        /* chknorm */
+        addi a0, s2, 0
+        li   t0, GAMMA1
+        li   t1, BETA
+        sub  a1, t0, t1
+        jal x1, poly_chknorm
 
-    /* Cannot use hardware loop due to branch to _rej_crypto_sign_signature_internal */
-    .rept K
-        addi a0, s0, 0
-        jal  x1, poly_chknorm
-        /* reject */
-        bne  a0, zero, _rej_crypto_sign_signature_internal
-        addi s0, s0, 1024
+        bne a0, zero, _rej_crypto_sign_signature_internal
+
+        /* Speculatively pack z[i] into the signature. */
+        addi a0, s9, 0
+        addi a1, s2, 0
+        jal x1, polyz_pack
+        /* Update the pointer to the end of the packed part. */
+        addi s9, a0, 0
     .endr
 
-    /* make hint */
-    li  s0, 0
-    li  s1, STACK_H
-    add a0, fp, s1
-    li  a1, STACK_W0
-    add a1, fp, a1
-    li  a2, STACK_W1
-    add a2, fp, a2
+    /* get *sig + CTILDEBYTES + L*POLYZ_PACKEDBYTES */
+    addi a0, s9, 0
 
-    LOOPI K, 4
-        add  a0, fp, s1
-        jal  x1, poly_make_hint
-        addi s1, s1, 1024
-        add  s0, s0, a0
+    /* Set hint bytes at end of signature (length omega + k) to 0. Round to
+       next word boundary. */
+    li    t1, OMEGA
+    addi  t1, t1, K
+    addi  t1, t1, 3
+    srli  t1, t1, 2
+    LOOP  t1, 2
+      sw   x0, 0(a0)
+      addi a0, a0, 4
 
-    li   t0, OMEGA
-    li   t1, 1
-    /* This checks t0 < s0. Writes 1 if true, 0 else */
-    sub t2, t0, s0
-    srli t2, t2, 31
-    /* reject */
-    beq  t1, t2, _rej_crypto_sign_signature_internal
+    addi a0, s9, 0
 
-    /* Pack sig */
-    li   a0, STACK_SIG
-    add  a0, fp, a0
-    lw   a0, 0(a0)  /* get *sig */
-    /* c is already in sig */
-    addi a0, a0, CTILDEBYTES /* increment *sig */
-    /* z */
-    li   a1, STACK_Z
-    add  a1, fp, a1
-    LOOPI L, 2
-        jal x1, polyz_pack
-        nop
-
-    /* encode h */
-    /* save *sig + CTILDEBYTES + L*POLYZ_PACKEDBYTES */
-    addi s0, a0, 0
-
-    /* Set rest of sig to 0 */
-    li     t0, 31
-
-#if OMEGA == 80
-    bn.sid t0, 0(a0++)
-    bn.sid t0, 0(a0++)
-
-    LOOPI 5, 2
-        sw   zero, 0(a0)
-        addi a0, a0, 4
-#elif OMEGA == 55
-    bn.sid t0, 0(a0++)
-
-    LOOPI 7, 2
-        sw   zero, 0(a0)
-        addi a0, a0, 4
-    /* Set last byte to zero */
-    lw t1, 0(a0)
-    srli t1, t1, 8
-    slli t1, t1, 8
-    sw t1, 0(a0)
-#elif OMEGA == 75
-    bn.sid t0, 0(a0++)
-    bn.sid t0, 0(a0++)
-
-    LOOPI 4, 2
-        sw   zero, 0(a0)
-        addi a0, a0, 4
-    lw t1, 0(a0)
-    srli t1, t1, 24
-    slli t1, t1, 24
-    sw t1, 0(a0)
+    /* Load pointer to packed S2. */
+    li   s0, STACK_SK
+    add  s0, fp, s0
+    lw   s0, 0(s0)
+#if DILITHIUM_MODE == 2
+    addi s2, s0, 512
+#elif DILITHIUM_MODE == 3
+    addi s2, s0, 768
+#elif DILITHIUM_MODE == 5
+    addi s2, s0, 800
 #endif
 
-    addi a0, s0, 0 /* reset *sig */
-    li   a1, STACK_H
-    add  a1, fp, a1
-    jal  x1, polyvec_encode_h
+    /* Load pointer to packed T0. */
+#if DILITHIUM_MODE == 2
+    addi s0, s0, 896
+#elif DILITHIUM_MODE == 3
+    addi s0, s0, 1536
+#elif DILITHIUM_MODE == 5
+    addi s0, s0, 1568
+#endif
+
+    /* Initialize some pointers for the loop. */
+    li  s1, STACK_H
+    add s1, fp, s1
+    li  s3, STACK_W0
+    add s3, fp, s3
+    li  s5, STACK_W1
+    add s5, fp, s5
+    li  s7, STACK_CP
+    add s7, fp, s7
+    li  s10, STACK_TMP
+    add s10, fp, s10
+
+    /* Initialize the coefficient sum for the hint for post-check. */
+    li  s4, 0
+
+    /* Initialize the counter for the index in the hint vector. */
+    li  s6, 0
+
+    /* Normalize w0 to the [0, q) range (in-place). */
+    addi   a0, s3, 0
+    li     t1, 1
+    la     t0, modulus
+    bn.lid t1, 0(t0)
+    LOOPI K, 6
+        LOOPI 32, 4
+            bn.lid      x0, 0(a0)
+            bn.addv.8S  w0, w0, w1
+            bn.addvm.8S w0, bn0, w0
+            bn.sid      x0, 0(a0++)
+        NOP
+
+    /* This loop computes the hint one element at a time, and performs
+       rejection sampling. For each index i=0..k-1, it does:
+
+         tmp = cp * s2[i]
+         w0[i] -= tmp
+         tmp = reduce32(w0[i])
+         if not poly_chknorm(tmp, gamma - beta):
+           reject
+         tmp = cp * t0[i]
+         h = reduce32(tmp)
+         if not poly_chknorm(h, gamma):
+           reject
+         w0[i] += h
+         if not poly_chknorm(w0[i], gamma - beta):
+           reject
+         make_hint(h, w0[i], w1[i]) # gets written directly into signature
+     */
+    .rept K
+        /* Unpack the next polynomial from s2. */
+        addi a0, s10, 0
+        addi a1, s2, 0
+        jal  x1, polyeta_unpack
+        addi a0, a0, -1024
+
+        /* Update the packed s2 pointer. */
+        addi s2, a1, 0
+
+        bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
+
+        /* Compute ntt(s2[i]) in-place. */
+        la   a1, twiddles_fwd
+        addi a2, a0, 0
+        jal x1, ntt
+
+        /* tmp = cp * s2 */
+        addi a0, s10, 0
+        addi a1, s7, 0
+        addi a2, s10, 0
+        jal  x1, poly_pointwise
+
+        /* Inverse NTT on tmp */
+        addi a0, s10, 0
+        la  a1, twiddles_inv
+        jal x1, intt
+
+        bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
+
+        /* w0[i] -= tmp */
+        addi a0, s3, 0
+        addi a1, s10, 0
+        addi a2, s3, 0
+        jal  x1, poly_sub
+
+        /* tmp = reduce32(w0[i]) to move to mod^{+-} for bound check */
+        addi a0, s3, 0
+        addi a1, s10, 0
+        jal  x1, poly_reduce32
+
+        /* chknorm(tmp, gamma2 - beta) */
+        addi a0, s10, 0
+        li   t0, GAMMA2
+        li   t1, BETA
+        sub  a1, t0, t1
+        jal  x1, poly_chknorm
+        bne  a0, zero, _rej_crypto_sign_signature_internal
+
+        /* Unpack the next polynomial from t0. */
+        addi a0, s10, 0
+        addi a1, s0, 0
+        jal  x1, polyt0_unpack
+
+        /* Update the packed t0 pointer. */
+        addi s0, a1, 0
+
+        bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
+
+        /* Compute ntt(t0[i]) in-place. */
+        addi a0, s10, 0
+        la   a1, twiddles_fwd
+        addi a2, a0, 0
+        jal x1, ntt
+
+        /* tmp = cp * t0 */
+        addi a0, s10, 0
+        addi a1, s7, 0
+        addi a2, s10, 0
+        jal  x1, poly_pointwise
+
+        /* Inverse NTT on tmp */
+        addi a0, s10, 0
+        la  a1, twiddles_inv
+        jal x1, intt
+
+        bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
+
+        /* w0[i] += tmp */
+        addi a0, s3, 0
+        addi a1, s10, 0
+        addi a2, s3, 0
+        jal  x1, poly_add
+
+        /* h = reduce32(tmp) to move to mod^{+-} for bound check */
+        addi a0, s10, 0
+        addi a1, s1, 0
+        jal  x1, poly_reduce32
+
+        /* chknorm(h, gamma2) */
+        li   a1, GAMMA2
+        addi a0, s1, 0
+        jal  x1, poly_chknorm
+        bne  a0, zero, _rej_crypto_sign_signature_internal
+
+        /* h[i] = make_hint(w0[i], w1[i]) */
+        addi a0, s1, 0
+        addi a1, s3, 0
+        addi a2, s5, 0
+        jal x1, poly_make_hint
+
+        /* Update the coefficient sum accumulator (saving previous value). */
+        add  a2, s4, 0
+        add  s4, s4, a0
+
+        /* If the accumulator (# nonzero coeffs in h) is > omega, reject. */
+        li   t0, OMEGA
+        sub  t0, t0, s4
+        srli t0, t0, 31
+        bne  zero, t0, _rej_crypto_sign_signature_internal
+
+        /* Encode h[i] into the signature. */
+        addi a0, s9, 0
+        addi a1, s1, 0
+        addi a3, s6, 0
+        jal  x1, poly_encode_h
+
+        /* Increment i. */
+        addi s6, s6, 1
+        /* Update pointer into w0. */
+        addi s3, s3, 1024
+        /* Update pointer into w1. */
+        addi s5, s5, 1024
+    .endr
 
     /* Return success and signature length */
     li a0, 0

--- a/sw/otbn/crypto/mldsa/mldsa_sign.s
+++ b/sw/otbn/crypto/mldsa/mldsa_sign.s
@@ -185,28 +185,28 @@ crypto_sign_signature_internal:
     #define STACK_KEY -192 /* Prev - 32 */
       #define STACK_RHOPRIME -192 /* Prev */
     #define STACK_Y   -1216 /* Prev - 1024 */
-        #define STACK_S1  -1216 /* Prev */
-        #define STACK_H   -1216 /* Prev */
+      #define STACK_CP  -1216 /* Prev */
     #define STACK_TMP -2240 /* Prev - 1024 */
-    #define STACK_CP  -3264 /* Prev - 1024 */
+      #define STACK_H   -2240 /* Prev */
+      #define STACK_S1  -2240 /* Prev */
 #if DILITHIUM_MODE == 2
-    #define STACK_W1  -3392 /* Prev - K*32 */
-    #define STACK_W0  -7488 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -7488 /* Prev */
-    #define STACK_CTX  -7492 /* Prev - 4 */
-    #define INIT_SP -7520
+    #define STACK_W1  -2368 /* Prev - K*32 */
+    #define STACK_W0  -6464 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -6464 /* Prev */
+    #define STACK_CTX  -6468 /* Prev - 4 */
+    #define INIT_SP -6496
 #elif DILITHIUM_MODE == 3
-    #define STACK_W1  -3456 /* Prev - K*32 */
-    #define STACK_W0  -9600 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -9600 /* Prev */
-    #define STACK_CTX  -9604 /* Prev - 4 */
-    #define INIT_SP -9632
+    #define STACK_W1  -2432 /* Prev - K*32 */
+    #define STACK_W0  -8576 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -8576 /* Prev */
+    #define STACK_CTX  -8580 /* Prev - 4 */
+    #define INIT_SP -8608
 #elif DILITHIUM_MODE == 5
-    #define STACK_W1  -3520 /* Prev - K*32 */
-    #define STACK_W0  -11712 /* Prev - K*1024 */
-        #define STACK_CTXLEN  -11712 /* Prev */
-    #define STACK_CTX  -11716 /* Prev - 4 */
-    #define INIT_SP -11744
+    #define STACK_W1  -2496 /* Prev - K*32 */
+    #define STACK_W0  -10688 /* Prev - K*1024 */
+        #define STACK_CTXLEN  -10688 /* Prev */
+    #define STACK_CTX  -10692 /* Prev - 4 */
+    #define INIT_SP -10720
 #endif
 
     /* Initialize the frame pointer */
@@ -496,6 +496,9 @@ _rej_crypto_sign_signature_internal:
        for entry A[i][j]. */
     li s4, 0
 
+    /* Load a constant pointer to the zero wide register. */
+    li s5, 31
+
     /* Compute A * y, computing the values for A and y on the fly.
 
        We compute column-wise so that we genearate elements of y only once; in
@@ -507,6 +510,11 @@ _rej_crypto_sign_signature_internal:
              w[i] += A[i][j] * yj
     */
     .rept L
+        /* Zero the buffer for y[j]. */
+        li   a0, STACK_Y
+        add  a0, fp, a0
+        loopi 32, 1
+          bn.sid s5, 0(a0++)
         /* Compute y[j]. */
         li   a0, STACK_Y
         add  a0, fp, a0
@@ -756,8 +764,8 @@ _rej_crypto_sign_signature_internal:
 
         bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
 
-        /* Sample the next value of y and reuse s1 buffer to store it. */
-        addi a0, s1, 0
+        /* Sample the next value of y and add it to z. */
+        addi a0, s2, 0
         addi a1, s3, 0
         addi a2, s8, 0
         addi a3, s10, 0
@@ -765,12 +773,6 @@ _rej_crypto_sign_signature_internal:
 
         /* Update the nonce for y. */
         addi s8, a2, 1
-
-        /* z[i] += y[i] */
-        addi a0, s1, 0
-        addi a1, s2, 0
-        addi a2, s2, 0
-        jal x1, poly_add
 
         /* reduce32(z) to move to mod^{+-} for bound check */
         addi a0, s2, 0

--- a/sw/otbn/crypto/mldsa/mldsa_sign.s
+++ b/sw/otbn/crypto/mldsa/mldsa_sign.s
@@ -591,8 +591,9 @@ _rej_crypto_sign_signature_internal:
     addi a2, s11, 0 /* Compute nonce */
     la   a3, gamma1_vec_const
 
-    LOOPI L, 2
+    LOOPI L, 3
         jal  x1, poly_uniform_gamma_1
+        addi a0, a0, 1024
         addi a2, a2, 1 /* a2 should be preserved after execution */
 
     addi s11, s11, L

--- a/sw/otbn/crypto/mldsa/mldsa_sign.s
+++ b/sw/otbn/crypto/mldsa/mldsa_sign.s
@@ -189,45 +189,45 @@ crypto_sign_signature_internal:
     #define STACK_S1  -8384 /* Prev - L*1024 */
     #define STACK_S2  -12480 /* Prev - K*1024 */
     #define STACK_MAT  -13504 /* Prev - 1024 */
+      #define STACK_CP  -13504 /* Prev */
     #define STACK_Y  -17600 /* Prev - K*1024 */
         #define STACK_H  -17600 /* Prev */
     #define STACK_Z  -21696 /* Prev - L*1024 */
     #define STACK_W1  -25792 /* Prev - K*1024 */
     #define STACK_W0  -29888 /* Prev - K*1024 */
-    #define STACK_CP  -30912 /* Prev - 1024 */
-        #define STACK_CTXLEN  -30912 /* Prev */
-    #define STACK_CTX  -30916 /* Prev - 4 */
-    #define INIT_SP -30944
+        #define STACK_CTXLEN  -29888 /* Prev */
+    #define STACK_CTX  -29892 /* Prev - 4 */
+    #define INIT_SP -29920
 
 #elif DILITHIUM_MODE == 3
     #define STACK_T0  -6336 /* Prev - K*1024 */
     #define STACK_S1  -11456 /* Prev - L*1024 */
     #define STACK_S2  -17600 /* Prev - K*1024 */
     #define STACK_MAT  -18624 /* Prev - 1024 */
+      #define STACK_CP  -18624 /* Prev */
     #define STACK_Y  -24768 /* Prev - K*1024 */
         #define STACK_H  -24768 /* Prev */
     #define STACK_Z  -29888 /* Prev - L*1024 */
     #define STACK_W1  -36032 /* Prev - K*1024 */
     #define STACK_W0  -42176 /* Prev - K*1024 */
-    #define STACK_CP  -43200 /* Prev - 1024 */
-        #define STACK_CTXLEN  -43200 /* Prev */
-    #define STACK_CTX  -43204 /* Prev - 4 */
-    #define INIT_SP -43232
+        #define STACK_CTXLEN  -42176 /* Prev */
+    #define STACK_CTX  -42180 /* Prev - 4 */
+    #define INIT_SP -42208
 
 #elif DILITHIUM_MODE == 5
     #define STACK_T0  -8384 /* Prev - K*1024 */
     #define STACK_S1  -15552 /* Prev - L*1024 */
     #define STACK_S2  -23744 /* Prev - K*1024 */
     #define STACK_MAT  -24768 /* Prev - 1024 */
+      #define STACK_CP  -24768 /* Prev */
     #define STACK_Y  -32960 /* Prev - K*1024 */
         #define STACK_H  -32960 /* Prev */
     #define STACK_Z  -40128 /* Prev - L*1024 */
     #define STACK_W1  -48320 /* Prev - K*1024 */
     #define STACK_W0  -56512 /* Prev - K*1024 */
-    #define STACK_CP  -57536 /* Prev - 1024 */
-        #define STACK_CTXLEN  -57536 /* Prev */
-    #define STACK_CTX  -57540 /* Prev - 4 */
-    #define INIT_SP -57568
+        #define STACK_CTXLEN  -56512 /* Prev */
+    #define STACK_CTX  -56516 /* Prev - 4 */
+    #define INIT_SP -56544
 
 #endif
     /* Initialize the frame pointer */

--- a/sw/otbn/crypto/mldsa/mldsa_sign.s
+++ b/sw/otbn/crypto/mldsa/mldsa_sign.s
@@ -183,13 +183,12 @@ crypto_sign_signature_internal:
     #define STACK_RHO -128 /* Prev - 32 */
     #define STACK_RND -160 /* Prev - 32 */
     #define STACK_KEY -192 /* Prev - 32 */
-    #define STACK_RHOPRIME -192 /* Prev */
+      #define STACK_RHOPRIME -192 /* Prev */
 #if DILITHIUM_MODE == 2
     #define STACK_T0  -4288 /* Prev - K*1024 */
     #define STACK_S1  -8384 /* Prev - L*1024 */
     #define STACK_S2  -12480 /* Prev - K*1024 */
-    #define STACK_MAT  -13504 /* Prev - 1024 */
-      #define STACK_CP  -13504 /* Prev */
+    #define STACK_CP  -13504 /* Prev - 1024 */
     #define STACK_Y  -14528 /* Prev - 1024 */
     #define STACK_Z  -18624 /* Prev - L*1024 */
     #define STACK_W1  -22720 /* Prev - K*1024 */
@@ -203,8 +202,7 @@ crypto_sign_signature_internal:
     #define STACK_T0  -6336 /* Prev - K*1024 */
     #define STACK_S1  -11456 /* Prev - L*1024 */
     #define STACK_S2  -17600 /* Prev - K*1024 */
-    #define STACK_MAT  -18624 /* Prev - 1024 */
-      #define STACK_CP  -18624 /* Prev */
+    #define STACK_CP  -18624 /* Prev - 1024 */
     #define STACK_Y  -19648 /* Prev - 1024 */
     #define STACK_Z  -24768 /* Prev - L*1024 */
     #define STACK_W1  -30912 /* Prev - K*1024 */
@@ -218,8 +216,7 @@ crypto_sign_signature_internal:
     #define STACK_T0  -8384 /* Prev - K*1024 */
     #define STACK_S1  -15552 /* Prev - L*1024 */
     #define STACK_S2  -23744 /* Prev - K*1024 */
-    #define STACK_MAT  -24768 /* Prev - 1024 */
-      #define STACK_CP  -24768 /* Prev */
+    #define STACK_CP  -24768 /* Prev - 1024 */
     #define STACK_Y  -25792 /* Prev - 1024 */
     #define STACK_Z  -32960 /* Prev - L*1024 */
     #define STACK_W1  -41152 /* Prev - K*1024 */
@@ -349,7 +346,7 @@ crypto_sign_signature_internal:
     li t2, STACK_CTXLEN
     add a0, fp, t2
     lw t2, 0(a0) /* t2 <= ctxlen */
-    li t3, STACK_CP /* Re-use CP buffer for absorbing ctxlen and ctx */
+    li t3, STACK_Z /* Re-use Z buffer for absorbing ctxlen and ctx */
     add t3, fp, t3
 
     /* Note: Add support for non-4B multiple ctxlen */
@@ -449,7 +446,7 @@ crypto_sign_signature_internal:
     /* a1 still contains length but includes TRBYTES */
     addi a1, a1, -TRBYTES
 
-    li t3, STACK_CP /* Re-use CP buffer for absorbing ctxlen and ctx */
+    li t3, STACK_Z /* Re-use Z buffer for absorbing ctxlen and ctx */
     add a0, fp, t3
 
     jal x1, keccak_send_message
@@ -583,24 +580,16 @@ crypto_sign_signature_internal:
 _rej_crypto_sign_signature_internal:
     /* Matrix-vector multiplication */
 
-    /* Save some stack offsets. */
-    li s0, STACK_Y
-    add s0, fp, s0
+    /* Get destination pointer. */
     li s1, STACK_W1
     add s1, fp, s1
-    li s2, STACK_MAT
-    add s2, fp, s2
-    li s3, STACK_RHOPRIME
-    add s3, fp, s3
-    li s5, STACK_RHO
-    add s5, fp, s5
 
     /* Initialize destination to 0. */
     li t0, 31
-    addi a3, s1, 0
+    addi t1, s1, 0
     LOOPI K, 3
         LOOPI 32, 1
-          bn.sid t0, 0(a3++)
+          bn.sid t0, 0(t1++)
         nop
 
     /* Load the constant for resetting the w1 pointer. */
@@ -622,8 +611,8 @@ _rej_crypto_sign_signature_internal:
              w1[i] += A[i][j] * yj
     */
     .rept L
-        /* Compute y[j], storing temporarily in the matrix poly buffer. */
-        li   a0, STACK_MAT
+        /* Compute y[j]. */
+        li   a0, STACK_Y
         add  a0, fp, a0
         li   a1, STACK_RHOPRIME
         add  a1, fp, a1
@@ -632,7 +621,7 @@ _rej_crypto_sign_signature_internal:
         jal  x1, poly_uniform_gamma_1
         addi s11, a2, 1 /* a2 should be preserved after execution */
         /* Compute ntt(y[j]). */
-        li   a0, STACK_MAT
+        li   a0, STACK_Y
         add  a0, fp, a0
         la  a1, twiddles_fwd
         li   a2, STACK_Y
@@ -642,13 +631,13 @@ _rej_crypto_sign_signature_internal:
             /* Compute A[i][j]. */
             li   a0, STACK_RHO
             add  a0, fp, a0
-            li   a1, STACK_MAT
+            li   a1, STACK_Z
             add  a1, fp, a1
             addi a2, s4, 0 /* matrix nonce */
             jal  x1, poly_uniform
             li   a0, STACK_Y
             add  a0, fp, a0
-            li   a1, STACK_MAT
+            li   a1, STACK_Z
             add  a1, fp, a1
             addi a2, s1, 0 /* *W1[i] */
             /* Add A[i][j] * y[j] to w1[i]. */
@@ -748,69 +737,45 @@ _rej_crypto_sign_signature_internal:
 
     /* Setup WDR */
     li t1, 8
+    /* Restore a0. */
+    addi a0, s0, 0
 
+    /* Read first 32 bytes of digest. */
+    bn.wsrr w8, 0xA
+
+    /* Get temp buffer */
+    /* Get always-aligned temporary buffer. */
+    li   t0, STACK_CP
+    add  t0, fp, t0
 #if CTILDEBYTES == 32
-    bn.wsrr w8, 0xA   /* KECCAK_DIGEST */
-    addi    a0, s0, 0 /* restore a0 */
-    /* Get temp buffer */
-    li   t0, STACK_CP
-    add  t0, fp, t0
-    bn.sid  t1, 0(t0) /* Store CTILDE into temp buffer */
-    LOOPI 8, 4
-        lw t2, 0(t0)
-        sw t2, 0(a0)
-        addi t0, t0, 4
-        addi a0, a0, 4
-
-    addi a0, a0, -CTILDEBYTES
+    /* Store first 32 bytes into temp buffer and signature. */
+    bn.sid  t1, 0(t0)
+    bn.sid  t1, 0(a0)
 #elif CTILDEBYTES == 48
-    bn.wsrr w8, 0xA   /* KECCAK_DIGEST */
-    addi    a0, s0, 0 /* restore a0 */
-
-    /* Get temp buffer */
-    li   t0, STACK_CP
-    add  t0, fp, t0
-    bn.sid  t1, 0(t0) /* Store CTILDE into temp buffer */
+    /* Store first 32 bytes into temp buffer and (unaligned) signature. */
+    bn.sid  t1, 0(t0)
     LOOPI 8, 4
         lw t2, 0(t0)
         sw t2, 0(a0)
         addi t0, t0, 4
         addi a0, a0, 4
 
-    bn.wsrr w8, 0xA   /* KECCAK_DIGEST */
-
-    bn.sid  t1, 0(t0) /* Store CTILDE into temp buffer */
+    /* Read 32 more bytes and store 16 of them. */
+    bn.wsrr w8, 0xA
+    bn.sid  t1, 0(t0)
     LOOPI 4, 4
         lw t2, 0(t0)
         sw t2, 0(a0)
         addi t0, t0, 4
         addi a0, a0, 4
-
-    addi a0, a0, -CTILDEBYTES
 #elif CTILDEBYTES == 64
-    bn.wsrr w8, 0xA   /* KECCAK_DIGEST */
-    addi    a0, s0, 0 /* restore a0 */
-
-    /* Get temp buffer */
-    li   t0, STACK_CP
-    add  t0, fp, t0
-    bn.sid  t1, 0(t0) /* Store CTILDE into temp buffer */
-    LOOPI 8, 4
-        lw t2, 0(t0)
-        sw t2, 0(a0)
-        addi t0, t0, 4
-        addi a0, a0, 4
-
-    bn.wsrr w8, 0xA   /* KECCAK_DIGEST */
-
-    bn.sid  t1, 0(t0) /* Store CTILDE into temp buffer */
-    LOOPI 8, 4
-        lw t2, 0(t0)
-        sw t2, 0(a0)
-        addi t0, t0, 4
-        addi a0, a0, 4
-
-    addi a0, a0, -CTILDEBYTES
+    /* Store first 32 bytes into temp buffer and signature. */
+    bn.sid  t1, 0(t0)
+    bn.sid  t1, 0(a0)
+    /* Store 32 more bytes (both places). */
+    bn.wsrr w8, 0xA
+    bn.sid  t1, 32(t0)
+    bn.sid  t1, 32(a0)
 #endif
 
     /* Finish the SHAKE-256 operation. */

--- a/sw/otbn/crypto/mldsa/mldsa_sign.s
+++ b/sw/otbn/crypto/mldsa/mldsa_sign.s
@@ -195,18 +195,21 @@ crypto_sign_signature_internal:
         #define STACK_CTXLEN  -6464 /* Prev */
     #define STACK_CTX  -6468 /* Prev - 4 */
     #define INIT_SP -6496
+    #define STACK_SIZE 6624 /* Expected stack size for reference (unused). */
 #elif DILITHIUM_MODE == 3
     #define STACK_W1  -2432 /* Prev - K*32 */
     #define STACK_W0  -8576 /* Prev - K*1024 */
         #define STACK_CTXLEN  -8576 /* Prev */
     #define STACK_CTX  -8580 /* Prev - 4 */
     #define INIT_SP -8608
+    #define STACK_SIZE 8736 /* Expected stack size for reference (unused). */
 #elif DILITHIUM_MODE == 5
     #define STACK_W1  -2496 /* Prev - K*32 */
     #define STACK_W0  -10688 /* Prev - K*1024 */
         #define STACK_CTXLEN  -10688 /* Prev */
     #define STACK_CTX  -10692 /* Prev - 4 */
     #define INIT_SP -10720
+    #define STACK_SIZE 10848 /* Expected stack size for reference (unused). */
 #endif
 
     /* Initialize the frame pointer */

--- a/sw/otbn/crypto/mldsa/mldsa_sign.s
+++ b/sw/otbn/crypto/mldsa/mldsa_sign.s
@@ -499,6 +499,18 @@ _rej_crypto_sign_signature_internal:
     /* Load a constant pointer to the zero wide register. */
     li s5, 31
 
+    /* Load a pointer to the vectorized gamma1. */
+    la   s7, gamma1_vec_const
+
+    /* Load a pointer to the NTT twiddles. */
+    la   s9, twiddles_fwd
+
+    /* Load other pointers. */
+    li   s8, STACK_Y
+    add  s8, fp, s8
+    li   s10, STACK_TMP
+    add  s10, fp, s10
+
     /* Compute A * y, computing the values for A and y on the fly.
 
        We compute column-wise so that we genearate elements of y only once; in
@@ -509,41 +521,32 @@ _rej_crypto_sign_signature_internal:
            for i in 0..k-1:
              w[i] += A[i][j] * yj
     */
-    .rept L
+    loopi L, 29
         /* Zero the buffer for y[j]. */
-        li   a0, STACK_Y
-        add  a0, fp, a0
+        addi  t0, s8, 0
         loopi 32, 1
-          bn.sid s5, 0(a0++)
+          bn.sid s5, 0(t0++)
         /* Compute y[j]. */
-        li   a0, STACK_Y
-        add  a0, fp, a0
-        li   a1, STACK_RHOPRIME
-        add  a1, fp, a1
+        addi a0, s8, 0
+        add  a1, fp, STACK_RHOPRIME
         addi a2, s11, 0 /* y sampling nonce */
-        la   a3, gamma1_vec_const
+        addi a3, s7, 0
         jal  x1, poly_uniform_gamma_1
         addi s11, a2, 1 /* a2 should be preserved after execution */
         bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
         /* Compute ntt(y[j]). */
-        li   a0, STACK_Y
-        add  a0, fp, a0
-        la  a1, twiddles_fwd
-        li   a2, STACK_Y
-        add  a2, fp, a2
+        addi a0, s8, 0
+        addi a1, s9, 0
+        addi a2, s8, 0
         jal x1, ntt
-        .rept K
+        loopi K, 10
             /* Compute A[i][j]. */
-            li   a0, STACK_RHO
-            add  a0, fp, a0
-            li   a1, STACK_TMP
-            add  a1, fp, a1
+            addi a0, fp, STACK_RHO
+            addi a1, s10, 0
             addi a2, s4, 0 /* matrix nonce */
             jal  x1, poly_uniform
-            li   a0, STACK_Y
-            add  a0, fp, a0
-            li   a1, STACK_TMP
-            add  a1, fp, a1
+            addi a0, s8, 0
+            addi a1, s10, 0
             addi a2, s1, 0 /* *w[i] */
             /* Add A[i][j] * y[j] to w[i]. */
             jal  x1, poly_pointwise_acc
@@ -551,7 +554,6 @@ _rej_crypto_sign_signature_internal:
             addi s1, s1, 1024
             /* Increment the row index by 1. */
             addi s4, s4, 256
-         .endr
         /* Reset w pointer. */
         sub  s1, s1, s6
         /* Increment the column index in the nonce by one. */
@@ -559,7 +561,6 @@ _rej_crypto_sign_signature_internal:
         /* Reset the row index in the nonce to zero. */
         andi s4, s4, 255
         bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
-    .endr
 
     bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
     /* Inverse NTT on w */
@@ -623,7 +624,7 @@ _rej_crypto_sign_signature_internal:
 
        Afterwards, the w1[i] value can be discarded, so we do not need to keep
        two w-sized polyvecs in scope at once. */
-    .rept K
+    loopi K, 14
         /* Decompose w and store w0 in-place, w1 in tmp. */
         addi   a0, s0, 0
         addi   a1, s4, 0
@@ -635,7 +636,7 @@ _rej_crypto_sign_signature_internal:
         jal    x1, polyw1_pack
         /* Send packed w1 to the Keccak core. */
         addi   a0, s2, 0
-        li     a1, POLYW1_PACKEDBYTES
+        addi   a1, zero, POLYW1_PACKEDBYTES
         jal    x1, keccak_send_message
         /* Calculate the coefficients of w1 that are nonzero mod q, and store them. */
         addi   a0, s4, 0
@@ -643,7 +644,6 @@ _rej_crypto_sign_signature_internal:
         bn.sid x0, 0(s1++)
         /* Increment w pointer. */
         addi s0, s0, 1024
-    .endr
 
     /* Setup WDR */
     li t1, 8

--- a/sw/otbn/crypto/mldsa/ntt.s
+++ b/sw/otbn/crypto/mldsa/ntt.s
@@ -1,4 +1,5 @@
 /* Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors */
+/* Copyright zeroRISC Inc. */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* Modified by Ruben Niederhagen and Hoang Nguyen Hien Pham - authors of */
@@ -33,7 +34,7 @@
  * @param[in]  w31: all-zero
  * @param[out] x12: dmem pointer to result
  *
- * clobbered registers: x4-x30, w2-w25, w30
+ * clobbered registers: x4-x27, w0-w15, w17-w19, w24-w30
  */
 .globl ntt
 ntt:

--- a/sw/otbn/crypto/mldsa/poly.s
+++ b/sw/otbn/crypto/mldsa/poly.s
@@ -654,7 +654,7 @@ _loop_inner_skip_load_poly_challenge:
  * @param[in]  a2: nonce
  * @param[out] a1: dmem pointer to polynomial
  *
- * clobbered registers: a0-a5, t0-t5, w8, w16
+ * clobbered registers: a0-a5, t0-t6, w8, w16
  */
 .global poly_uniform
 poly_uniform:
@@ -2009,8 +2009,6 @@ poly_uniform_gamma_1:
     /* copy output pointer */
     addi t1, a0, 0
 
-    push a1
-
     /* Initialize a SHAKE256 operation. */
     addi a0, a1, 0    /* save a0 <= seed address */
 
@@ -2107,8 +2105,6 @@ poly_uniform_gamma_1:
 
     /* Finish the SHAKE-256 operation. */
 
-    pop a1
-
     ret
 
 _inner_poly_uniform_gamma_1:
@@ -2129,8 +2125,6 @@ _inner_poly_uniform_gamma_1:
 #elif GAMMA1 == (1 << 19)
     /* copy output pointer */
     addi t1, a0, 0
-
-    push a1
 
     /* Initialize a SHAKE256 operation. */
     addi a0, a1, 0    /* a0 <= seed address */
@@ -2200,8 +2194,6 @@ _inner_poly_uniform_gamma_1:
         nop /* Must not end on branch */
 
     /* Finish the SHAKE-256 operation. */
-
-    pop a1
 
     ret
 

--- a/sw/otbn/crypto/mldsa/poly.s
+++ b/sw/otbn/crypto/mldsa/poly.s
@@ -654,7 +654,7 @@ _loop_inner_skip_load_poly_challenge:
  * @param[in]  a2: nonce
  * @param[out] a1: dmem pointer to polynomial
  *
- * clobbered registers: a0-a5, t0-t6, w8, w16
+ * clobbered registers: a0-a5, t0-t6, w8, w21
  */
 .global poly_uniform
 poly_uniform:
@@ -957,9 +957,9 @@ _aligned_poly_uniform_eta:
     /* Initialize constants */
     bn.addi w14, bn0, 0x0F
 #if ETA == 2
-    bn.addi w16, bn0, 15
+    bn.addi w21, bn0, 15
 #elif ETA == 4
-    bn.addi w16, bn0, 9
+    bn.addi w21, bn0, 9
 #endif
     li a5, 8
     li a6, 2
@@ -989,7 +989,7 @@ LOOPI 64, 13
         bn.and  w9, shake_reg, w14            /* Mask out all other bits */
 
         /* Check "t0" < {15,9} */
-        bn.cmp w9, w16
+        bn.cmp w9, w21
         csrrs a4, 0x7C0, zero
         /* If the MSB of t0 - {15,9} is not set, we know that t0 >= {15,9}
            and thus, we have to reject. */
@@ -1891,7 +1891,7 @@ polyt0_unpack:
     /* Load mask for zeroing the upper bits of the unpacked coefficients. */
     li t2, 5
     la t3, polyt0_unpack_mask
-    bn.lid t5, 0(t3)
+    bn.lid t2, 0(t3)
 
     /* Setup WDR */
     li t2, 2
@@ -2605,54 +2605,57 @@ _inner_polyz_pack:
                                  WDR */
     ret
 #endif
+
 /**
- * polyvec_encode_h
+ * poly_encode_h
  *
- * Encode h to signature from polyvec h.
+ * Encode hint to signature from single polynomial h[i].
  *
  * Flags: -
  *
- * @param[in]  a1: pointer to input polynomial h
- * @param[out] a0: pointer to output byte array signature
+ * @param[in]  a1: pointer to input polynomial h[i]
+ * @param[in]  a2: k, number of nonzero h coefficients so far
+ * @param[in]  a3: i, index of this polynomial in h
+ * @param[out] a0: pointer to the start of all signature hint bytes
  *
  * clobbered registers: a1-a2, t0-t6
  */
-.global polyvec_encode_h
-polyvec_encode_h:
-    li t0, 0 /* k = 0 */
-    li t1, 0 /* i = 0 */
-
+.global poly_encode_h
+poly_encode_h:
     /* Masking constant for alignment */
-    li a2, 0xFFFFFFFC
-    LOOPI K, 25
-        li t2, 0 /* j = 0 */
-        LOOPI N, 13
-            lw   t3, 0(a1)
-            addi a1, a1, 4   /* Increment input pointer */
-            beq  zero, t3, _skip_store_polyvec_encode_h
-            add  t4, a0, t0  /* *sig + k */
-            andi t5, t4, 0x3 /* preserve lower 2 bits */
-            and  t4, t4, a2  /* align */
-            lw   t6, 0(t4)   /* load form aligned(sig+k) */
-            slli t5, t5, 3   /* #bytes -> #bits */
-            sll  t5, t2, t5  /* j << #bits */
-            or   t6, t6, t5
-            sw   t6, 0(t4)
+    li t0, 0xFFFFFFFC
 
-            addi t0, t0, 1 /* k++ */
-_skip_store_polyvec_encode_h:
-            addi t2, t2, 1
-        addi t2, t1, OMEGA /* OMEGA + i */
+    /* j = 0 (index within h[i]) */
+    li t2, 0
+
+    /* Loop through each coefficient and store indices of nonzero ones. */
+    LOOPI N, 13
+        lw   t3, 0(a1)
+        addi a1, a1, 4   /* Increment input pointer */
+        beq  zero, t3, _skip_store_poly_encode_h
+        add  t4, a0, a2  /* *sig + k */
+        andi t5, t4, 0x3 /* preserve lower 2 bits */
+        and  t4, t4, t0  /* align */
+        lw   t6, 0(t4)   /* load form aligned(sig+k) */
+        slli t5, t5, 3   /* #bytes -> #bits */
+        sll  t5, t2, t5  /* j << #bits */
+        or   t6, t6, t5
+        sw   t6, 0(t4)
+
+        addi a2, a2, 1 /* k++ */
+_skip_store_poly_encode_h:
+        addi t2, t2, 1
+
+        /* Store the number of nonzero coefficients after h[i] at the end. */
+        addi t2, a3, OMEGA /* OMEGA + i */
         add  t2, a0, t2    /* *sig + OMEGA + i */
         andi t3, t2, 0x3   /* preserve lower 2 bits */
-        and  t2, t2, a2    /* align */
+        and  t2, t2, t0    /* align */
         lw   t4, 0(t2)     /* load from aligned(*sig + OMEGA + i) */
         slli t3, t3, 3     /* #bytes -> #bits */
-        sll  t3, t0, t3    /* k << #bits */
+        sll  t3, a2, t3    /* k << #bits */
         or   t4, t4, t3
         sw   t4, 0(t2)
-
-        addi t1, t1, 1
 
     ret
 

--- a/sw/otbn/crypto/mldsa/poly.s
+++ b/sw/otbn/crypto/mldsa/poly.s
@@ -2039,14 +2039,18 @@ _inner_polyt0_unpack:
  *  Sample polynomial with uniformly random coefficients in [-(GAMMA1 - 1),
  *  GAMMA1] by unpacking output stream of SHAKE256(seed|nonce).
  *
+ * Accumulates the result onto the existing value in the output polynomial
+ * register; the caller should zero this value if only the sampling output is
+ * desired.
+ *
  * Flags: -
  *
- * @param[out] a0: pointer to output polynomial
+ * @param[out] a0: pointer to accumulator on which to add output
  * @param[in]  a1: byte array with seed of length CRHBYTES
  * @param[in]  a2: nonce
  * @param[in]  a3: pointer to gamma1_vec_const
  *
- * clobbered registers: a0, a4, t0-t6, w1-w2, w8
+ * clobbered registers: a1, t0-t3, w1-w6
  */
 .global poly_uniform_gamma_1
 poly_uniform_gamma_1:
@@ -2165,6 +2169,8 @@ _inner_poly_uniform_gamma_1:
 
     bn.and     w2, w2, w5 /* Mask unpacked coeffs to 18 bit */
     bn.subvm.8S w2, w4, w2 /* w2 <= gamma1_eta_const - w2 */
+    bn.lid     x0, 0(t1)
+    bn.addvm.8S w2, w0, w2
     bn.sid     t2, 0(t1++)
     ret
 #elif GAMMA1 == (1 << 19)
@@ -2255,6 +2261,8 @@ _inner_poly_uniform_gamma_1:
 
     bn.and     w2, w2, w5 /* Mask unpacked coeffs to 20 bit */
     bn.subvm.8S w2, w4, w2 /* w2 <= gamma1_eta_const - w2 */
+    bn.lid     x0, 0(t1)
+    bn.addvm.8S w2, w0, w2
     bn.sid     t2, 0(t1++)
     ret
 #endif

--- a/sw/otbn/crypto/mldsa/poly.s
+++ b/sw/otbn/crypto/mldsa/poly.s
@@ -1519,6 +1519,51 @@ _inner_polyt0_pack:
     ret
 
 /**
+ * poly_nonzero_encode
+ *
+ * Compactly encode the coefficients of the polynomial which are nonzero mod q.
+ *
+ * The bit at index (255-i) in the output 256-bit value is 1 if and only if the
+ * coefficient i of the input is nonzero mod q. The bits are in "reverse order"
+ * for more convenient iteration later; when iterating from MSb->LSb a single
+ * bn.add can simultaneously capture the next bit in the carry flag and also
+ * shift all the other bits.
+ *
+ * Expects input in the range [0, q).
+ *
+ * Flags: -
+ *
+ * @param[in]  a0: pointer to input polynomial
+ * @param[out] w0: Representative of nonzero coefficients.
+ *
+ * clobbered registers: a0, t0, w0-w4
+ */
+.global poly_nonzero_encode
+poly_nonzero_encode:
+    /* Initialize accumulator to zero. */
+    bn.mov w0, w31
+
+    /* Create a 32-bit mask. */
+    bn.not w2, w31
+    bn.rshi w2, w31, w2 >> 224
+
+    /* Set up WDR pointer. */
+    li  t0, 1
+
+    /* Loop through the coefficients. */
+    loopi 32, 8
+        bn.lid t0, 0(a0++)
+        loopi 8, 5
+          bn.add   w0, w0, w0
+          bn.addi  w3, w0, 1
+          bn.and   w4, w1, w2
+          bn.sel   w0, w0, w3, FG0.Z
+          bn.rshi  w1, w31, w1 >> 32
+        nop
+
+    ret
+
+/**
  * polyw1_pack
  *
  * Bit-pack polynomial w1 with coefficients fitting in 6 bits. Input
@@ -2224,8 +2269,8 @@ _inner_poly_uniform_gamma_1:
  * Flags: -
  *
  * @param[out] a0: a0 pointer to output polynomial with coefficients c0
- * @param[out] a1: a1: pointer to output polynomial with coefficients c1
- * @param[in]  a2: *a: pointer to input polynomial
+ * @param[out] a1: a1 pointer to output polynomial with coefficients c1
+ * @param[in]  a2: *a, pointer to input polynomial
  *
  * clobbered registers: w0-w11, a0-a2, t0-t4
  */
@@ -2288,11 +2333,14 @@ poly_decompose:
  *  the high bits.
  *  The function accepts inputs mod^+ q.
  *
+ * Expects the high part of the polynomial to be represented with 256 bits, in
+ * the format produced by poly_nonzero_encode_dilithium.
+ *
  * Returns: Number of one bits
  *
  * @param[out] a0: pointer to output hint polynomial
  * @param[in]  a1: a0 pointer to low part of input polynomial
- * @param[in]  a2: a1: pointer to high part of input polynomial
+ * @param[in]  w0: 256b representative of nonzero values in high part of polynomial
  *
  * clobbered registers: t0-t2, t4-t6, a0-a2, a4-a7
  */
@@ -2311,7 +2359,6 @@ poly_make_hint:
     /* Loop over every coefficient pair of the input */
     LOOPI 256, 21
         lw t0, 0(a1)
-        lw t1, 0(a2)
 
         sub t5, t6, t0 /* Check t0 < (gamma2 + 1) <=> 0 < (gamma2 + 1) - t0 */
         srli t3, t5, 31
@@ -2323,12 +2370,16 @@ poly_make_hint:
 
         bne t0, a7, _return1
         li t3, 0
+
+        /* Branch to the end if the high part coefficient is 0. */
+        bn.add  w0, w0, w0
+        csrrs   t1, FG0, zero
+        andi    t1, t1, 1
         beq t1, zero, _loop_end_poly_make_hint
-        beq t1, a6, _loop_end_poly_make_hint
-        beq zero, zero, _return1
+        jal x0, _return1
 _return0:
         li t3, 0
-        beq zero, zero, _loop_end_poly_make_hint
+        jal x0, _loop_end_poly_make_hint
 _return1:
         li t3, 1
         /* Fall through to loop end */
@@ -2336,7 +2387,6 @@ _loop_end_poly_make_hint:
         sw   t3, 0(a0) /* Write to output polynomial */
         add  t2, t2, t3
         addi a1, a1, 4
-        addi a2, a2, 4
         addi a0, a0, 4
 
     addi a0, t2, 0 /* move result to return value */

--- a/sw/otbn/crypto/mldsa/poly.s
+++ b/sw/otbn/crypto/mldsa/poly.s
@@ -1,4 +1,5 @@
 /* Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors */
+/* Copyright zeroRISC Inc. */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
@@ -452,18 +453,6 @@ _inner_polyz_unpack:
  */
  .global poly_chknorm
 poly_chknorm:
-    /* save fp to stack */
-    addi sp, sp, -32
-    sw   fp, 0(sp)
-
-    addi fp, sp, 0
-
-    /* Adjust sp to accomodate local variables */
-    addi sp, sp, -32
-
-    /* Reserve space for tmp buffer to hold a WDR */
-    #define STACK_WDR2GPR -32
-
     /* Load modulus Q */
     la   t0, modulus
     lw   t1, 0(t0)
@@ -496,9 +485,9 @@ _loop_poly_chknorm:
     bn.and     w2, w2, w3
     /* w2 <= w1 - w2 */
     bn.subv.8S  w2, w1, w2
-    bn.sid      t2, STACK_WDR2GPR(fp)
+    la          t4, poly_wdr2gpr
+    bn.sid      t2, 0(t4)
 
-    addi t4, fp, STACK_WDR2GPR
     /* Check bound */
     .irp    offset,0,4,8,12,16,20,24,28
         lw  t3, \offset(t4)
@@ -511,20 +500,10 @@ _loop_poly_chknorm:
     bne a0, t0, _loop_poly_chknorm
 
 _ret0_poly_chknorm:
-    /* sp <- fp */
-    addi sp, fp, 0
-    /* Pop ebp */
-    lw fp, 0(sp)
-    addi sp, sp, 32
     /* return success */
     li a0, 0
     ret
 _ret1_poly_chknorm:
-    /* sp <- fp */
-    addi sp, fp, 0
-    /* Pop ebp */
-    lw fp, 0(sp)
-    addi sp, sp, 32
     /* return fail */
     li a0, 1
     ret
@@ -542,22 +521,10 @@ _ret1_poly_chknorm:
  * @param[in]  a1: mu byte array containing seed of length CTILDEBYTES
  * @param[out] a0: pointer to output polynomial
  *
- * clobbered registers: a0-a5, t0-t3, w0-w3
+ * clobbered registers: a0-a5, t0-t4, w0-w3
  */
 .global poly_challenge
 poly_challenge:
-    /* save fp to stack */
-    addi sp, sp, -32
-    sw   fp, 0(sp)
-
-    addi fp, sp, 0
-
-    /* Adjust sp to accomodate local variables */
-    addi sp, sp, -32
-
-    /* Reserve space for tmp buffer to hold a WDR */
-    #define STACK_WDR2GPR -32
-
     /* save output pointer */
     addi a4, a0, 0
 
@@ -592,6 +559,9 @@ poly_challenge:
     /* Setup WDR */
     li t0, 0
     li a6, 3
+
+    /* Set up pointer to tmp buffer. */
+    la t4, poly_wdr2gpr
 
     /* fill signs */
 
@@ -631,12 +601,12 @@ _loop_inner_poly_challenge:
         bn.wsrr w0, 0xA /* KECCAK_DIGEST */
         li      a2, 256 /* reset the remaining bits counter */
 _loop_inner_skip_load_poly_challenge:
-        /* Store w0 to the stack in order to read one word into a GPR */
-        bn.sid  t0, STACK_WDR2GPR(fp)
+        /* Store w0 to memory in order to read one word into a GPR */
+        bn.sid  t0, 0(t4)
         bn.rshi w0, bn0, w0 >> 8 /* shift out used bits */
         addi    a2, a2, -8 /* decrease number of remaining bits */
         /* NOTE: optimize this to use all bytes from this load */
-        lw      t1, STACK_WDR2GPR(fp) /* get one word of SHAKE output into GPR */
+        lw      t1, 0(t4) /* get one word of SHAKE output into GPR */
         /* t1 = b from the reference implementation */
         andi    t1, t1, 0xFF /* mask out one byte, because we only need one */
         sub     t2, a3, t1 /* i <? b */
@@ -661,8 +631,8 @@ _loop_inner_skip_load_poly_challenge:
         bn.and  w3, w1, w2            /* signs & 1 */
         bn.add  w3, w3, w3            /* 2 * (signs & 1) */
         bn.subm  w3, w2, w3            /* 1 - 2 * (signs & 1) */
-        bn.sid  a6, STACK_WDR2GPR(fp) /* Store w3 to memory to move value to GPR */
-        lw      t2, STACK_WDR2GPR(fp)
+        bn.sid  a6, 0(t4) /* Store w3 to memory to move value to GPR */
+        lw      t2, 0(t4)
         sw      t2, 0(t1)             /* c->coeffs[b] = 1 - 2*(signs & 1); */
 
         bn.rshi w1, bn0, w1 >> 1 /* Discard the used bit: signs >>= 1 */
@@ -670,13 +640,6 @@ _loop_inner_skip_load_poly_challenge:
         addi a3, a3, 1 /* i++ */
 
     /* Finish the SHAKE-256 operation. */
-
-    /* sp <- fp */
-    addi sp, fp, 0
-
-    /* Pop ebp */
-    lw   fp, 0(sp)
-    addi sp, sp, 32
 
     ret
 
@@ -1094,164 +1057,97 @@ _poly_uniform_eta_arithmetic:
  * @param[out]    a1: input poly pointer
  * @param[out]    a2: input hint poly pointer
  *
- * clobbered registers: a0-a5, t0-t6, w0-w11
+ * clobbered registers: a0-a2, t0-t1, w0-w15, w30
  */
 .global poly_use_hint
 poly_use_hint:
-    /* save fp to stack */
-    addi sp, sp, -32
-    sw fp, 0(sp)
-
-    addi fp, sp, 0
-
-    /* Adjust sp to accomodate local variables */
-    addi sp, sp, -64
-
-    /* Reserve space for tmp buffer to hold a WDR */
-    #define STACK_WDR2GPR1 -32
-    #define STACK_WDR2GPR2 -64
-    addi a3, a0, 1024 /* overall stop address */
-
-    /* Constants */
-    li a4, 43
-    li a5, 1
-    li a6, 2
-
     /* WDR constants for decompose */
     la t0, decompose_127_const
     li t1, 5
     /* w5 <= decompose_127_const */
-    bn.lid t1, 0(t0)
+    bn.lid t1++, 0(t0)
 
     la t0, decompose_const
-    li t1, 6
     /* w6 <= decompose_const */
-    bn.lid t1, 0(t0)
+    bn.lid t1++, 0(t0)
 
     la t0, reduce32_const
-    li t1, 7
     /* w7 <= reduce32_const */
-    bn.lid t1, 0(t0)
+    bn.lid t1++, 0(t0)
 
     la t0, decompose_43_const
-    li t1, 8
     /* w8 <= decompose_43_const */
-    bn.lid t1, 0(t0)
+    bn.lid t1++, 0(t0)
 
     la t0, gamma2_vec_const
-    li t1, 9
     /* w9 <= gamma2_vec_const */
-    bn.lid t1, 0(t0)
+    bn.lid t1++, 0(t0)
 
     la t0, qm1half_const
-    li t1, 10
     /* w10 <= qm1half_const */
-    bn.lid t1, 0(t0)
+    bn.lid t1++, 0(t0)
 
     la t0, modulus
-    li t1, 11
     /* w11 <= modulus */
-    bn.lid t1, 0(t0)
+    bn.lid t1++, 0(t0)
 
-_loop_poly_use_hint:
-    /* vectorized part: decompose */
-    li     t0, 0
-    bn.lid t0, 0(a1++)
-    jal    x1, decompose
+    /* Save the value from the modulus register. */
+    bn.wsrr w15, MOD
 
-    /* Store result form decomposition do dmem */
-    bn.sid a5, STACK_WDR2GPR1(fp)
-    bn.sid a6, STACK_WDR2GPR2(fp)
+    /* Construct the modulus for the hint (decompose_43_const + 1). This is
+       either (vectorized) 44 or 16, depending on the parameters. */
+    bn.shv.8S w12, w5 >> 6
+    bn.addv.8S w12, w12, w8
+    bn.wsrw MOD, w12
 
-    /* "a{0,1}" refers to the variables from the reference code */
+    /* In pseudocode, this loop implements (for input polynomial r):
+       for i = 0..255:
+         r0, r1 = decompose(r[i])
+         if hint == 0:
+           return r1
+         if r0 > 0:
+           return (r1 + 1) % ((q - 1) / (2 * gamma2))
+         else:
+           return (r1 - 1) % ((q - 1) / (2 * gamma2))
+       We implement the if/else cases using bitwise operations so that we can
+       vectorize the process, but the code does not actually need to be
+       constant-time.
 
-    addi t2, fp, STACK_WDR2GPR1 /* "a0" */
-    addi t3, fp, STACK_WDR2GPR2 /* "a1" */
-    addi t4, a0, 32             /* stop address */
+       The hint values are assumed to be always 0 or 1, and decompose output is
+       assumed to be <= (q - 1) / 2 * gamma2 (16 or 44 depending on gamma2).
 
-    /* scalar part starts here */
-#if GAMMA2 == (Q-1)/88
-    LOOPI 8, 24
-        lw  t1, 0(t3) /* Load "a1" */
-        /* Check if hint is 0 */
-        lw  t5, 0(a2)
-        bne t5, zero, _inner_loop_skip_store1_poly_use_hint
-        sw  t1, 0(a0)
-        beq zero, zero, _inner_loop_end_poly_use_hint
-_inner_loop_skip_store1_poly_use_hint:
-        /* if(0 < "a0") */
-        lw t5, 0(t2)
-        sub t5, zero, t5
-        srli t5, t5, 31
-        bne t5, a5, _inner_loop_else_poly_use_hint /* go to else-branch */
-        /* if("a1" == 43) */
-        bne t1, a4, _inner_loop_aplus1_poly_use_hint /* go to else-branch */
-        sw zero, 0(a0) /* return 0 */
-        beq zero, zero, _inner_loop_end_poly_use_hint /* go to iteration end */
-_inner_loop_aplus1_poly_use_hint:
-        /* if("a1" == 43) else-branch */
-        /* Store "a1" + 1 */
-        addi t1, t1, 1
-        sw t1, 0(a0)
-        beq zero, zero, _inner_loop_end_poly_use_hint /* unconditional */
-_inner_loop_else_poly_use_hint:
-        /* if(0 < "a0") else-branch */
-        /* if("a1" == 0) */
-        bne t1, zero, _inner_loop_aminus1_poly_use_hint /* go to else-branch */
-        /* Store 43 */
-        sw a4, 0(a0)
-        beq zero, zero, _inner_loop_end_poly_use_hint
-_inner_loop_aminus1_poly_use_hint:
-        /* if("a1" == 0) else-branch */
-        /* Store "a1" - 1 */
-        addi t1, t1, -1
-        sw t1, 0(a0)
-_inner_loop_end_poly_use_hint:
-        addi t3, t3, 4 /* increment "a1" pointer */
-        addi a0, a0, 4 /* increment output */
-        addi t2, t2, 4 /* increment "a0" pointer */
-        addi a2, a2, 4 /* increment *hint */
-        /* LOOP END */
-#elif GAMMA2 == (Q-1)/32
-    LOOPI 8, 20
-        lw  t1, 0(t3) /* Load "a1" */
-        /* Check if hint is 0 */
-        lw  t5, 0(a2)
-        bne t5, zero, _inner_loop_skip_store1_poly_use_hint
-        sw  t1, 0(a0)
-        beq zero, zero, _inner_loop_end_poly_use_hint
-_inner_loop_skip_store1_poly_use_hint:
-        /* if(0 < "a0") */
-        lw t5, 0(t2)
-        sub t5, zero, t5
-        srli t5, t5, 31
-        bne t5, a5, _inner_loop_else_poly_use_hint /* go to else-branch */
+       The reference code calls r0, r1 "a0" and "a1", but we use r here to
+       avoid confusion with register names.
+    */
+    LOOPI 32, 11
+      /* Load the next values from the input polynomial and decompose them.
+           w1 <= r0[i*8:(i+1)*8]
+           w2 <= r1[i*8:(i+1)*8] */
+      bn.lid x0, 0(a1++)
+      jal    x1, decompose
 
-        /* if-branch */
-        addi t1, t1, 1
-        andi t1, t1, 15
-        sw t1, 0(a0)
-        beq zero, zero, _inner_loop_end_poly_use_hint
+      /* Load the next values from the hint into w0. */
+      bn.lid x0, 0(a2++)
 
-_inner_loop_else_poly_use_hint:
-        /* else-branch */
-        addi t1, t1, -1
-        andi t1, t1, 15
-        sw t1, 0(a0)
-_inner_loop_end_poly_use_hint:
-        addi t3, t3, 4 /* increment "a1" pointer */
-        addi a0, a0, 4 /* increment output */
-        addi t2, t2, 4 /* increment "a0" pointer */
-        addi a2, a2, 4 /* increment *hint */
-        /* LOOP END */
-#endif
-    bne a3, a0, _loop_poly_use_hint
+      /* w12[j] <= 1 if r0[8*i+j] < 0 or r0[8*i+j] == 0 and h == 1, otherwise 0 */
+      bn.subv.8S w1, w1, w0
+      bn.shv.8S w12, w1 >> 31
 
-    /* sp <- fp */
-    addi sp, fp, 0
-    /* Pop ebp */
-    lw fp, 0(sp)
-    addi sp, sp, 32
+      /* w13[j] <= 1 if h[8*i+j] == 1 and r0[8*i+j] <= 0 */
+      bn.and w13, w12, w0
+
+      /* w12[j] <= 1 if h[8*i+j] == 1 and r0[8*i+j] > 0 */
+      bn.xor w12, w12, w0
+      bn.and w12, w12, w0
+
+      /* Compute and store the final result. */
+      bn.addvm.8S w0, w2, w12
+      bn.subvm.8S w0, w0, w13
+      bn.sid x0, 0(a0++)
+
+    /* Restore the previous value of the MOD register. */
+    bn.wsrw MOD, w15
+
     ret
 
 /**
@@ -2110,19 +2006,9 @@ _inner_polyt0_unpack:
 .global poly_uniform_gamma_1
 poly_uniform_gamma_1:
 #if GAMMA1 == (1 << 17)
-    /* save fp to stack */
-    addi sp, sp, -32
-    sw fp, 0(sp)
+    /* copy output pointer */
+    addi t1, a0, 0
 
-    addi fp, sp, 0
-
-    /* Adjust sp to accomodate local variables */
-    addi sp, sp, -32
-
-    /* Reserve space for tmp buffer to hold a WDR */
-    #define STACK_WDR2GPR -32
-
-    push a0
     push a1
 
     /* Initialize a SHAKE256 operation. */
@@ -2140,13 +2026,13 @@ poly_uniform_gamma_1:
     jal  x1, keccak_send_message
 
     /* Send the nonce to the Keccak core. */
-    sw   a2, STACK_WDR2GPR(fp)
-    addi a0, fp, STACK_WDR2GPR /* a0 <= *STACK_WDR2GPR = *nonce*/
+    la   a0, poly_wdr2gpr
+    sw   a2, 0(a0)
     li   a1, 2 /* a1 <= 2 */
     jal  x1, keccak_send_message
 
-    pop a1
-    pop a0
+    /* restore original value of output pointer */
+    addi a0, t1, 0
 
     /* Load gamma1 as a vector into w4 */
     li t2, 4
@@ -2221,11 +2107,7 @@ poly_uniform_gamma_1:
 
     /* Finish the SHAKE-256 operation. */
 
-    /* sp <- fp */
-    addi sp, fp, 0
-    /* Pop ebp */
-    lw fp, 0(sp)
-    addi sp, sp, 32
+    pop a1
 
     ret
 
@@ -2242,22 +2124,12 @@ _inner_poly_uniform_gamma_1:
 
     bn.and     w2, w2, w5 /* Mask unpacked coeffs to 18 bit */
     bn.subvm.8S w2, w4, w2 /* w2 <= gamma1_eta_const - w2 */
-    bn.sid     t2, 0(a0++)
+    bn.sid     t2, 0(t1++)
     ret
 #elif GAMMA1 == (1 << 19)
-/* save fp to stack */
-    addi sp, sp, -32
-    sw fp, 0(sp)
+    /* copy output pointer */
+    addi t1, a0, 0
 
-    addi fp, sp, 0
-
-    /* Adjust sp to accomodate local variables */
-    addi sp, sp, -32
-
-    /* Reserve space for tmp buffer to hold a WDR */
-    #define STACK_WDR2GPR -32
-
-    push a0
     push a1
 
     /* Initialize a SHAKE256 operation. */
@@ -2275,13 +2147,13 @@ _inner_poly_uniform_gamma_1:
     jal  x1, keccak_send_message
 
     /* Send the nonce to the Keccak core. */
-    sw   a2, STACK_WDR2GPR(fp)
-    addi a0, fp, STACK_WDR2GPR /* a0 <= *STACK_WDR2GPR = *nonce*/
+    la   a0, poly_wdr2gpr
+    sw   a2, 0(a0)
     li   a1, 2 /* a1 <= 2 */
     jal  x1, keccak_send_message
 
-    pop a1
-    pop a0
+    /* restore original value of output pointer */
+    addi a0, t1, 0
 
     /* Load gamma1 as a vector into w4 */
     li t2, 4
@@ -2329,11 +2201,8 @@ _inner_poly_uniform_gamma_1:
 
     /* Finish the SHAKE-256 operation. */
 
-    /* sp <- fp */
-    addi sp, fp, 0
-    /* Pop ebp */
-    lw fp, 0(sp)
-    addi sp, sp, 32
+    pop a1
+
     ret
 
 _inner_poly_uniform_gamma_1:
@@ -2349,7 +2218,7 @@ _inner_poly_uniform_gamma_1:
 
     bn.and     w2, w2, w5 /* Mask unpacked coeffs to 20 bit */
     bn.subvm.8S w2, w4, w2 /* w2 <= gamma1_eta_const - w2 */
-    bn.sid     t2, 0(a0++)
+    bn.sid     t2, 0(t1++)
     ret
 #endif
 /**
@@ -2896,3 +2765,18 @@ poly_power2round:
         bn.sid t3, 0(a1++)
 
     ret
+
+.data
+
+/* Aligned buffer to store a WDR value. */
+.balign 32
+.weak poly_wdr2gpr
+poly_wdr2gpr:
+.word 0
+.word 0
+.word 0
+.word 0
+.word 0
+.word 0
+.word 0
+.word 0

--- a/sw/otbn/crypto/mldsa/rounding.s
+++ b/sw/otbn/crypto/mldsa/rounding.s
@@ -157,7 +157,7 @@
  * decompose_const, reduce32_const, decompose_43_const, gamma2_vec_const,
  * qm1half_const, modulus
  *
- * clobbered registers: w1-w4, t0, t3-t4
+ * clobbered registers: w1-w4, w30
  */
 .global decompose
 decompose:

--- a/sw/otbn/crypto/tests/mldsa/mldsa_keypair_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_keypair_test.s
@@ -951,3 +951,6 @@ poly_uniform_eta_5:
     .word 5
     .word 5
     .word 5
+.global poly_wdr2gpr
+poly_wdr2gpr:
+    .zero 32

--- a/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
@@ -3991,3 +3991,6 @@ poly_uniform_eta_5:
     .word 5
     .word 5
     .word 5
+.global poly_wdr2gpr
+poly_wdr2gpr:
+    .zero 32

--- a/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
@@ -39,7 +39,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1312
 #define CRYPTO_SECRETKEYBYTES 2560
 #define CRYPTO_BYTES 2420
-#define STACK_SIZE 11616 /* minimum 12KB */
+#define STACK_SIZE 7648 /* minimum 8KB */
 
 #elif DILITHIUM_MODE == 3
 #define K 6
@@ -55,7 +55,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1952
 #define CRYPTO_SECRETKEYBYTES 4032
 #define CRYPTO_BYTES 3309
-#define STACK_SIZE 15712 /* minimum 16KB */
+#define STACK_SIZE 9760 /* minimum 10KB */
 
 #elif DILITHIUM_MODE == 5
 #define K 8
@@ -71,7 +71,7 @@
 #define CRYPTO_PUBLICKEYBYTES 2592
 #define CRYPTO_SECRETKEYBYTES 4896
 #define CRYPTO_BYTES 4627
-#define STACK_SIZE 19808 /* minimum 20KB */
+#define STACK_SIZE 11872 /* minimum 12KB */
 
 #endif
 

--- a/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
@@ -39,7 +39,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1312
 #define CRYPTO_SECRETKEYBYTES 2560
 #define CRYPTO_BYTES 2420
-#define STACK_SIZE 7648 /* minimum 8KB */
+#define STACK_SIZE 6624 /* minimum 7KB */
 
 #elif DILITHIUM_MODE == 3
 #define K 6
@@ -55,7 +55,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1952
 #define CRYPTO_SECRETKEYBYTES 4032
 #define CRYPTO_BYTES 3309
-#define STACK_SIZE 9760 /* minimum 10KB */
+#define STACK_SIZE 8736 /* minimum 9KB */
 
 #elif DILITHIUM_MODE == 5
 #define K 8
@@ -71,7 +71,7 @@
 #define CRYPTO_PUBLICKEYBYTES 2592
 #define CRYPTO_SECRETKEYBYTES 4896
 #define CRYPTO_BYTES 4627
-#define STACK_SIZE 11872 /* minimum 12KB */
+#define STACK_SIZE 10848 /* minimum 11KB */
 
 #endif
 

--- a/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
@@ -1,4 +1,5 @@
 /* Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors */
+/* Copyright zeroRISC Inc. */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 /* Modified by Ruben Niederhagen and Hoang Nguyen Hien Pham - authors of */
@@ -38,7 +39,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1312
 #define CRYPTO_SECRETKEYBYTES 2560
 #define CRYPTO_BYTES 2420
-#define STACK_SIZE 51200 /* minimum 50KB */
+#define STACK_SIZE 31072 /* minimum 32KB */
 
 #elif DILITHIUM_MODE == 3
 #define K 6
@@ -54,7 +55,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1952
 #define CRYPTO_SECRETKEYBYTES 4032
 #define CRYPTO_BYTES 3309
-#define STACK_SIZE 78848 /* minimum 77KB */
+#define STACK_SIZE 43360 /* minimum 44KB */
 
 #elif DILITHIUM_MODE == 5
 #define K 8
@@ -70,7 +71,7 @@
 #define CRYPTO_PUBLICKEYBYTES 2592
 #define CRYPTO_SECRETKEYBYTES 4896
 #define CRYPTO_BYTES 4627
-#define STACK_SIZE 120832 /* minimum 118KB */
+#define STACK_SIZE 57696 /* minimum 58KB */
 
 #endif
 
@@ -208,17 +209,15 @@ main:
 
 .data
 .balign 32
-#if DILITHIUM_MODE == 2
-.global stack
-stack:
-    .zero 2528 /* STACK_SIZE + STACK_SIGNATURE */
+/* Stack (labelled at the end). */
+.zero STACK_SIZE
+stack_end:
 
+#if DILITHIUM_MODE == 2
 .globl signature
 signature:
   .zero CRYPTO_BYTES
   .zero 12
-
-.zero 17408 /* STACK_SIZE + STACK_MAT - (CRYPTO_BYTES + 12) - 1504 */
 
 .globl sk
 sk:
@@ -888,14 +887,7 @@ message:
 messagelen:
   .word 0x00000040
 
-  .zero 23072
-stack_end:
-
 #elif DILITHIUM_MODE == 3
-.global stack
-stack:
-    .zero 2656 /* STACK_SIZE + STACK_SIGNATURE */
-
 /* In case of Dilithium3, CTILDEBYTES is 48, not divisible by 32.
    To make the packing easier, we dis-align the start of the signature buffer
    because we will simply need to write C to the beginning, which is much easier
@@ -905,8 +897,6 @@ stack:
 signature:
   .zero CRYPTO_BYTES
   .zero 3
-
-.zero 24576 /* STACK_SIZE + STACK_MAT - (CRYPTO_BYTES + 12) - 79328 */
 
 .globl sk
 sk:
@@ -1944,20 +1934,11 @@ message:
 messagelen:
   .word 0x00000040
 
-  .zero 41056
-stack_end:
-
 #elif DILITHIUM_MODE == 5
-.global stack
-stack:
-    .zero 2368 /* STACK_SIZE + STACK_SIGNATURE */
-
 .globl signature
 signature:
   .zero CRYPTO_BYTES
   .zero 13
-
-.zero 32768 /* STACK_SIZE + STACK_MAT - (CRYPTO_BYTES + 13) - 9536 */
 
 .globl sk
 sk:
@@ -3210,9 +3191,6 @@ message:
 .globl messagelen
 messagelen:
   .word 0x00000040
-
-  .zero 72960
-stack_end:
 #endif
 
 .balign 32

--- a/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
@@ -39,7 +39,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1312
 #define CRYPTO_SECRETKEYBYTES 2560
 #define CRYPTO_BYTES 2420
-#define STACK_SIZE 26976 /* minimum 27KB */
+#define STACK_SIZE 11616 /* minimum 12KB */
 
 #elif DILITHIUM_MODE == 3
 #define K 6
@@ -55,7 +55,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1952
 #define CRYPTO_SECRETKEYBYTES 4032
 #define CRYPTO_BYTES 3309
-#define STACK_SIZE 37216 /* minimum 38KB */
+#define STACK_SIZE 15712 /* minimum 16KB */
 
 #elif DILITHIUM_MODE == 5
 #define K 8
@@ -71,7 +71,7 @@
 #define CRYPTO_PUBLICKEYBYTES 2592
 #define CRYPTO_SECRETKEYBYTES 4896
 #define CRYPTO_BYTES 4627
-#define STACK_SIZE 49504 /* minimum 50KB */
+#define STACK_SIZE 19808 /* minimum 20KB */
 
 #endif
 

--- a/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
@@ -39,7 +39,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1312
 #define CRYPTO_SECRETKEYBYTES 2560
 #define CRYPTO_BYTES 2420
-#define STACK_SIZE 30048 /* minimum 31KB */
+#define STACK_SIZE 26976 /* minimum 27KB */
 
 #elif DILITHIUM_MODE == 3
 #define K 6
@@ -55,7 +55,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1952
 #define CRYPTO_SECRETKEYBYTES 4032
 #define CRYPTO_BYTES 3309
-#define STACK_SIZE 42336 /* minimum 43KB */
+#define STACK_SIZE 37216 /* minimum 38KB */
 
 #elif DILITHIUM_MODE == 5
 #define K 8
@@ -71,7 +71,7 @@
 #define CRYPTO_PUBLICKEYBYTES 2592
 #define CRYPTO_SECRETKEYBYTES 4896
 #define CRYPTO_BYTES 4627
-#define STACK_SIZE 56672 /* minimum 57KB */
+#define STACK_SIZE 49504 /* minimum 50KB */
 
 #endif
 

--- a/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_sign_test.s
@@ -39,7 +39,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1312
 #define CRYPTO_SECRETKEYBYTES 2560
 #define CRYPTO_BYTES 2420
-#define STACK_SIZE 31072 /* minimum 32KB */
+#define STACK_SIZE 30048 /* minimum 31KB */
 
 #elif DILITHIUM_MODE == 3
 #define K 6
@@ -55,7 +55,7 @@
 #define CRYPTO_PUBLICKEYBYTES 1952
 #define CRYPTO_SECRETKEYBYTES 4032
 #define CRYPTO_BYTES 3309
-#define STACK_SIZE 43360 /* minimum 44KB */
+#define STACK_SIZE 42336 /* minimum 43KB */
 
 #elif DILITHIUM_MODE == 5
 #define K 8
@@ -71,7 +71,7 @@
 #define CRYPTO_PUBLICKEYBYTES 2592
 #define CRYPTO_SECRETKEYBYTES 4896
 #define CRYPTO_BYTES 4627
-#define STACK_SIZE 57696 /* minimum 58KB */
+#define STACK_SIZE 56672 /* minimum 57KB */
 
 #endif
 

--- a/sw/otbn/crypto/tests/mldsa/mldsa_verify_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_verify_test.s
@@ -5150,3 +5150,6 @@ poly_uniform_eta_5:
     .word 5
     .word 5
     .word 5
+.global poly_wdr2gpr
+poly_wdr2gpr:
+    .zero 32


### PR DESCRIPTION
This PR is a follow-up from #30 that goes through the new multiplier code and re-applies the memory optimizations that had been applied to the old code in the `otbn-pqc` branch while the multiplier was under development. I split the commits out so that each one matches a specific memory-optimization commit in the history (referenced in each commit message). It should be possible to review this PR by looking at the changes from each old commit and check that these new commits are analogous.

I collected some summary stats just so we have some easy-to-reference info on what the memory optimizations cost with the new multiplier and how much the new multiplier improves performance on the memory-optimized code. In general the new multiplier made memory optimizations a little more costly, probably because with memory optimizations there are more non-multiplication operations that become relevant for performance.

Comparison to 3e6aef, new multiplier without memory optimization:
```
Stats for rejection loops in mldsa44_sign_test:
71957	-> 177151	(+105194 cycles, +146.19%)
69786	-> 157492	(+87706 cycles,  +125.68%)
75180	-> 215185	(+140005 cycles, +186.23%)
52721	-> 138077	(+85356 cycles,  +161.90%)
71173	-> 176229	(+105056 cycles, +147.61%)

Stats for rejection loops in mldsa65_sign_test:
99186	-> 284517	(+185331 cycles, +186.85%)

Stats for rejection loops in mldsa87_sign_test:
104333	-> 360873	(+256540 cycles, +245.89%)
147344	-> 520633	(+373289 cycles, +253.35%)
145500	-> 502098	(+356598 cycles, +245.08%)
106992	-> 377983	(+270991 cycles, +253.28%)
100080	-> 342141	(+242061 cycles, +241.87%)
```

Comparison to 9d0817, old multiplier with memory optimization:
```
Stats for rejection loops in mldsa44_sign_test:
200888	-> 177151	(-23737 cycles, -11.82%)
177524	-> 157492	(-20032 cycles, -11.28%)
246330	-> 215185	(-31145 cycles, -12.64%)
154405	-> 138077	(-16328 cycles, -10.57%)
199966	-> 176229	(-23737 cycles, -11.87%)

Stats for rejection loops in mldsa65_sign_test:
319207	-> 284517	(-34690 cycles, -10.87%)

Stats for rejection loops in mldsa87_sign_test:
391092	-> 360873	(-30219 cycles, -7.73%)
582342	-> 520633	(-61709 cycles, -10.60%)
560102	-> 502098	(-58004 cycles, -10.36%)
411906	-> 377983	(-33923 cycles, -8.24%)
368656	-> 342141	(-26515 cycles, -7.19%)
```