### PR TITLE
[mldsa] Reduce memory usage in verify to under 32kB for all parameters.

### DIFF
--- a/sw/otbn/crypto/mldsa/kmac_send_msg.s
+++ b/sw/otbn/crypto/mldsa/kmac_send_msg.s
@@ -16,6 +16,9 @@
  * the desired hash function. After calling this routine, reading from the
  * KECCAK_DIGEST special register will return the hash digest.
  *
+ * This function can be called repeatedly before reading the digest. On return,
+ * dptr_msg is updated to point to the end of the source buffer.
+ *
  * @param[in]   a1: len, byte-length of the message
  * @param[in]   a0: dptr_msg, pointer to message in DMEM
  * @param[in]   w31: all-zero
@@ -43,7 +46,7 @@ keccak_send_message:
       bn.lid  x0, 0(x10++)
       /* Write to the KECCAK_MSG wide special register (index 9).
          KECCAK_MSG <= w0 */
-      bn.wsrw 0x9, w0
+      bn.wsrw kmac_msg, w0
 #ifdef RTL_ISS_TEST
       LOOPI 300, 1
         NOP
@@ -58,8 +61,13 @@ _no_full_wdr:
   /* If the remaining length is zero, return early. */
   beq t0, x0, _keccak_send_message_end
 
+  /* Send a partial-word write. */
+  csrrw   x0, kmac_partial_write, t0
   bn.lid  x0, 0(x10)
-  bn.wsrw 0x9, w0
+  bn.wsrw kmac_msg, w0
+
+  /* Increment the source pointer to reflect the partial write. */
+  add     x10, x10, t0
 
   _keccak_send_message_end:
   ret

--- a/sw/otbn/crypto/mldsa/mldsa_verify.s
+++ b/sw/otbn/crypto/mldsa/mldsa_verify.s
@@ -625,6 +625,9 @@ crypto_sign_verify_internal:
     li   s7, 0
     li   s8, 0
 
+    /* Initialize failure buffer (0 on success, -1 on failure) */
+    li   s10, 0
+
     /* This loop computes w1 polynomials and sends them to the Keccak core
        incrementally. This way, we avoid ever storing the entire w1 on the
        stack. */
@@ -636,7 +639,7 @@ crypto_sign_verify_internal:
     li  s4, STACK_CP
     add s4, fp, s4
     la  s5, twiddles_fwd
-    .rept K
+    loopi K, 44
         /* Unpack the next polynomial from t1 and store it in temp buffer. */
         addi a0, s3, 0
         addi a1, s6, 0
@@ -667,16 +670,16 @@ crypto_sign_verify_internal:
         addi a0, s1, 0
         addi a1, s0, 0
         jal  x1, intt
-        /* Decode the next polynomial from the hint, failing on error. */
+        /* Decode the next polynomial from the hint and update the error register. */
         addi a0, s3, 0
         addi a1, s9, 0
         addi a2, s7, 0
         addi a3, s8, 0
         jal x1, poly_decode_h
-        bne a4, zero, _fail_crypto_sign_verify_internal
         addi s9, a1, 0
         addi s7, a2, 0
         addi s8, a3, 0
+        or   s10, s10, a4
         /* Use the hint to compute the next w1 polynomial. */
         addi a0, s1, 0
         addi a1, s1, 0
@@ -691,12 +694,14 @@ crypto_sign_verify_internal:
         addi a1, zero, POLYW1_PACKEDBYTES
         jal  x1, keccak_send_message
         addi s1, s1, 1024 /* increment *w1 */
-    .endr
+
+    bn.wsrr w8, 0xA /* KECCAK_DIGEST */
+
+    /* Check the failure register from the loop. */
+    bne s10, zero, _fail_crypto_sign_verify_internal
 
     /* Setup WDR for c2 */
     li t1, 8
-
-    bn.wsrr w8, 0xA /* KECCAK_DIGEST */
 
     /* Setup WDR for c */
     li t2, 9

--- a/sw/otbn/crypto/mldsa/mldsa_verify.s
+++ b/sw/otbn/crypto/mldsa/mldsa_verify.s
@@ -752,12 +752,10 @@ crypto_sign_verify_internal:
     /* Send buf to the Keccak core. */
     li  a0, STACK_BUF
     add a0, fp, a0
-    li a1, 0
-    LOOPI K, 1
-        addi a1, a1, POLYW1_PACKEDBYTES
-
-    /* li  a1, 768 */ /* set mu length to K*POLYW1_PACKEDBYTES */
-    jal x1, keccak_send_message
+    LOOPI K, 3
+        addi a1, zero, POLYW1_PACKEDBYTES
+        jal x1, keccak_send_message
+        nop
 
     /* Setup WDR for c2 */
     li t1, 8

--- a/sw/otbn/crypto/mldsa/mldsa_verify.s
+++ b/sw/otbn/crypto/mldsa/mldsa_verify.s
@@ -700,6 +700,9 @@ crypto_sign_verify_internal:
 
     bn.wsrr w8, 0xA /* KECCAK_DIGEST */
 
+    /* Restore MOD = R | Q to avoid clobbering, unused from here on. */
+    bn.wsrw mod, w16
+
     /* Check the failure register from the loop. */
     bne s10, zero, _fail_crypto_sign_verify_internal
 

--- a/sw/otbn/crypto/mldsa/mldsa_verify.s
+++ b/sw/otbn/crypto/mldsa/mldsa_verify.s
@@ -169,56 +169,47 @@
 .globl crypto_sign_verify_internal
 crypto_sign_verify_internal:
     /* Stack address mapping */
-    #define STACK_SIG -4
-    #define STACK_SIGLEN -8
-    #define STACK_MSG -12
+    #define STACK_SIG     -4
+    #define STACK_SIGLEN  -8
+    #define STACK_MSG    -12
     #define STACK_MSGLEN -16
-    #define STACK_PK -20
-    #define STACK_RHO -64
-    #define STACK_MU -128
+    #define STACK_PK     -20
+    #define STACK_CTX    -24
+    #define STACK_CTXLEN -28
+    #define STACK_RHO    -64
+    #define STACK_MU    -128
+    #define STACK_CP   -1152 /* Prev - 1024 */
+    #define STACK_TMP  -2176 /* Prev - 1024 */
 #if DILITHIUM_MODE == 2
-    #define STACK_T1 -4224 /* Prev - K*1024 */
-    #define STACK_C -4256 /* Prev - ceil(CTILDEBYTES/32)*32 */
-    #define STACK_Z -8352 /* Prev - L*1024 */
-    #define STACK_H -12448 /* Prev - K*1024 */
-    #define STACK_CP -13472 /* Prev - 1024 */
-    #define STACK_MAT -29856 /* Prev - K*L*1024 */
-    #define STACK_W1 -33952 /* Prev - K*1024 */
-        #define STACK_CTX -34716
-        #define STACK_CTXLEN -34720
+    #define STACK_T1  -6272 /* Prev - K*1024 */
+    #define STACK_C  -6304 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
+    #define STACK_Z  -10400 /* Prev - L*1024 */
+    #define STACK_H  -14496 /* Prev - K*1024 */
+    #define STACK_W1  -18592 /* Prev - K*1024 */
+    #define INIT_SP -18624
+
 #elif DILITHIUM_MODE == 3
-    #define STACK_T1 -6272 /* Prev - K*1024 */
-    #define STACK_C -6336 /* Prev - ceil(CTILDEBYTES/32)*32 */
-    #define STACK_Z -11456 /* Prev - L*1024 */
-    #define STACK_H -17600 /* Prev - K*1024 */
-    #define STACK_CP -18624 /* Prev - 1024 */
-    #define STACK_MAT -49344 /* Prev - K*L*1024 */
-    #define STACK_W1 -55488 /* Prev - K*1024 */
-        #define STACK_CTX -56252
-        #define STACK_CTXLEN -56256
+    #define STACK_T1  -8320 /* Prev - K*1024 */
+    #define STACK_C  -8384 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
+    #define STACK_Z  -13504 /* Prev - L*1024 */
+    #define STACK_H  -19648 /* Prev - K*1024 */
+    #define STACK_W1  -25792 /* Prev - K*1024 */
+    #define INIT_SP -25824
+
 #elif DILITHIUM_MODE == 5
-    #define STACK_T1 -8320 /* Prev - K*1024 */
-    #define STACK_C -8384 /* Prev - ceil(CTILDEBYTES/32)*32 */
-    #define STACK_Z -15552 /* Prev - L*1024 */
-    #define STACK_H -23744 /* Prev - K*1024 */
-    #define STACK_CP -24768 /* Prev - 1024 */
-    #define STACK_MAT -82112 /* Prev - K*L*1024 */
-    #define STACK_W1 -90304 /* Prev - K*1024 */
-        #define STACK_CTX -91324
-        #define STACK_CTXLEN -91328
+    #define STACK_T1  -10368 /* Prev - K*1024 */
+    #define STACK_C  -10432 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
+    #define STACK_Z  -17600 /* Prev - L*1024 */
+    #define STACK_H  -25792 /* Prev - K*1024 */
+    #define STACK_W1  -33984 /* Prev - K*1024 */
+    #define INIT_SP -34016
 #endif
 
     /* Initialize the frame pointer */
     addi fp, sp, 0
 
     /* Reserve space on the stack */
-#if DILITHIUM_MODE == 2
-    li  t0, -34720
-#elif DILITHIUM_MODE == 3
-    li  t0, -56256
-#elif DILITHIUM_MODE == 5
-    li  t0, -91328
-#endif
+    li  t0, INIT_SP
     add sp, sp, t0
 
     /* Store parameters to stack */
@@ -334,7 +325,7 @@ crypto_sign_verify_internal:
     /* reduce32(z) for central representation */
     li  a0, STACK_Z
     add a0, fp, a0
-    li  a1, STACK_MAT /* Use as temporary buffer */
+    li  a1, STACK_W1
     add a1, fp, a1
     LOOPI L, 2
         jal x1, poly_reduce32
@@ -344,7 +335,7 @@ crypto_sign_verify_internal:
     li  t0, GAMMA1
     li  t1, BETA
     sub a1, t0, t1
-    li  a0, STACK_MAT
+    li  a0, STACK_W1
     add a0, fp, a0
     addi s0, a0, 0
 
@@ -537,23 +528,6 @@ crypto_sign_verify_internal:
     add a1, fp, a1
     jal x1, poly_challenge
 
-    /* Expand matrix */
-    /* Initialize the nonce */
-    addi a2, zero, 0
-
-    li a1, STACK_MAT
-    add a1, fp, a1
-    LOOPI K, 10
-        LOOPI L, 7
-            /* Load parameters */
-            addi a0, fp, STACK_RHO
-            push a2
-            jal  x1, poly_uniform
-            pop a2
-            addi a2, a2, 1
-        addi a2, a2, 256
-        addi a2, a2, -L
-
     /* Prepare modulus */
     #define mod_x2 w22
     bn.wsrr   w16, 0x0 /* w16 = R | Q */
@@ -632,32 +606,55 @@ crypto_sign_verify_internal:
     .endr
 
     /* After NTT(t1), w16 is still R | Q and MOD is still 2*R | 2*Q */
-    /* Matrix-vector multiplication */
-    /* Load source pointers */
-    li  a0, STACK_Z
-    add a0, fp, a0
 
-    li  a1, STACK_MAT
-    add a1, fp, a1
+    /* Load source pointers for matrix-vector multiplication. */
+    li  s0, STACK_Z
+    add s0, fp, s0
+    li  s1, STACK_TMP
+    add s1, fp, s1
 
-    /* Load destination pointer */
-    li  a2, STACK_W1
-    add a2, fp, a2
+    /* Load destination pointer for matrix-vector multiplication. */
+    li  s2, STACK_W1
+    add s2, fp, s2
 
-    /* Load offset for resetting pointer */
-    li s1, POLYVECL_BYTES
+    /* Zero the destination buffer. */
+    li t0, 31
+    addi t1, s2, 0
+    LOOPI K, 3
+        LOOPI 32, 1
+          bn.sid t0, 0(t1++)
+        nop
 
-    .rept K
-        jal  x1, poly_pointwise
-        addi a2, a2, -1024
-        .rept L-1
+    /* Load offset for resetting vector pointer. */
+    li s3, POLYVECL_BYTES
+
+    /* Initialize the nonce for matrix expansion. This value should be
+         byte(i) || byte(j)
+       for entry A[i][j]. */
+    li s4, 0
+
+     /* Compute A * z, computing elements of A on the fly. */
+    loopi K, 15
+        loopi L, 10
+            /* Compute A[i][j]. */
+            addi a0, fp, STACK_RHO
+            addi a1, s1, 0
+            addi a2, s4, 0
+            jal  x1, poly_uniform
+            /* Increment the matrix nonce. */
+            addi s4, s4, 1
+            /* Compute A[i][j] * z[j] and add it to the output at index i. */
+            addi a0, s0, 0
+            addi a1, s1, 0
+            addi a2, s2, 0
             jal  x1, poly_pointwise_acc
-            addi a2, a2, -1024
-        .endr
+            addi s0, s0, 1024
         /* Reset input vector pointer */
-        sub  a0, a0, s1
-        addi a2, a2, 1024
-    .endr
+        sub  s0, s0, s3
+        addi s2, s2, 1024
+        /* Adjust the matrix nonce to reset the column and increment the row. */
+        addi s4, s4, 256
+        addi s4, s4, -L
 
     /* Call random oracle and verify challenge */
     /* Initialize a SHAKE256 operation. */

--- a/sw/otbn/crypto/mldsa/mldsa_verify.s
+++ b/sw/otbn/crypto/mldsa/mldsa_verify.s
@@ -184,7 +184,6 @@ crypto_sign_verify_internal:
     #define STACK_CP -13472 /* Prev - 1024 */
     #define STACK_MAT -29856 /* Prev - K*L*1024 */
     #define STACK_W1 -33952 /* Prev - K*1024 */
-    #define STACK_BUF -34720 /* Prev - K*128 */
         #define STACK_CTX -34716
         #define STACK_CTXLEN -34720
 #elif DILITHIUM_MODE == 3
@@ -195,7 +194,6 @@ crypto_sign_verify_internal:
     #define STACK_CP -18624 /* Prev - 1024 */
     #define STACK_MAT -49344 /* Prev - K*L*1024 */
     #define STACK_W1 -55488 /* Prev - K*1024 */
-    #define STACK_BUF -56256 /* Prev - K*128 */
         #define STACK_CTX -56252
         #define STACK_CTXLEN -56256
 #elif DILITHIUM_MODE == 5
@@ -206,7 +204,6 @@ crypto_sign_verify_internal:
     #define STACK_CP -24768 /* Prev - 1024 */
     #define STACK_MAT -82112 /* Prev - K*L*1024 */
     #define STACK_W1 -90304 /* Prev - K*1024 */
-    #define STACK_BUF -91328 /* Prev - K*128 */
         #define STACK_CTX -91324
         #define STACK_CTXLEN -91328
 #endif
@@ -712,28 +709,6 @@ crypto_sign_verify_internal:
         pop \reg
     .endr
 
-    /* Use hint */
-    li  a0, STACK_W1
-    add a0, fp, a0
-    li  a1, STACK_W1
-    add a1, fp, a1
-    li  a2, STACK_H
-    add a2, fp, a2
-
-    LOOPI K, 2
-        jal x1, poly_use_hint
-        nop
-
-    /* Pack w1 */
-    li  a1, STACK_W1
-    add a1, fp, a1
-    li  a0, STACK_BUF
-    add a0, fp, a0
-
-    LOOPI K, 2
-        jal x1, polyw1_pack
-        nop
-
     /* Call random oracle and verify challenge */
     /* Initialize a SHAKE256 operation. */
     li a1, CRHBYTES
@@ -749,12 +724,29 @@ crypto_sign_verify_internal:
     li  a1, CRHBYTES /* set mu length to CRHBYTES */
     jal x1, keccak_send_message
 
-    /* Send buf to the Keccak core. */
-    li  a0, STACK_BUF
-    add a0, fp, a0
-    LOOPI K, 3
+    /* This loop computes w1 polynomials and sends them to the Keccak core
+       incrementally. This way, we avoid ever storing the entire w1 on the
+       stack. */
+    li  s1, STACK_W1
+    add s1, fp, s1
+    li  s2, STACK_H
+    add s2, fp, s2
+    LOOPI K, 13
+        /* Use the hint to compute the next w1 polynomial. */
+        addi a0, s1, 0
+        addi a1, s1, 0
+        addi a2, s2, 0
+        jal  x1, poly_use_hint
+        addi s2, a2, 0
+        /* Pack the w1 polynomial (in-place). */
+        addi a0, s1, 0
+        addi a1, s1, 0
+        jal  x1, polyw1_pack
+        /* Send the packed w1 polynomial to the Keccak core. */
+        addi a0, s1, 0
+        addi s1, a1, 0 /* increment *w1 */
         addi a1, zero, POLYW1_PACKEDBYTES
-        jal x1, keccak_send_message
+        jal  x1, keccak_send_message
         nop
 
     /* Setup WDR for c2 */

--- a/sw/otbn/crypto/mldsa/mldsa_verify.s
+++ b/sw/otbn/crypto/mldsa/mldsa_verify.s
@@ -30,6 +30,7 @@
 
 #define POLYVECK_BYTES 4096
 #define POLYVECL_BYTES 4096
+#define Lminus1 3
 
 #define CRYPTO_PUBLICKEYBYTES 1312
 #define CRYPTO_SECRETKEYBYTES 2560
@@ -48,6 +49,7 @@
 
 #define POLYVECK_BYTES 6144
 #define POLYVECL_BYTES 5120
+#define Lminus1 4
 
 #define CRYPTO_PUBLICKEYBYTES 1952
 #define CRYPTO_SECRETKEYBYTES 4032
@@ -66,6 +68,7 @@
 
 #define POLYVECK_BYTES 8192
 #define POLYVECL_BYTES 7168
+#define Lminus1 6
 
 #define CRYPTO_PUBLICKEYBYTES 2592
 #define CRYPTO_SECRETKEYBYTES 4896
@@ -296,7 +299,7 @@ crypto_sign_verify_internal:
     /* reduce32(z) for central representation */
     li  a0, STACK_Z
     add a0, fp, a0
-    li  a1, STACK_W1
+    li  a1, STACK_W1 /* Use as temporary buffer. */
     add a1, fp, a1
     LOOPI L, 2
         jal x1, poly_reduce32
@@ -553,14 +556,6 @@ crypto_sign_verify_internal:
     li  s2, STACK_W1
     add s2, fp, s2
 
-    /* Zero the destination buffer. */
-    li t0, 31
-    addi t1, s2, 0
-    LOOPI K, 3
-        LOOPI 32, 1
-          bn.sid t0, 0(t1++)
-        nop
-
     /* Load offset for resetting vector pointer. */
     li s3, POLYVECL_BYTES
 
@@ -570,8 +565,21 @@ crypto_sign_verify_internal:
     li s4, 0
 
      /* Compute A * z, computing elements of A on the fly. */
-    loopi K, 15
-        loopi L, 10
+    loopi K, 25
+        /* Compute A[i][j]. */
+        addi a0, fp, STACK_RHO
+        addi a1, s1, 0
+        addi a2, s4, 0
+        jal  x1, poly_uniform
+        /* Increment the matrix nonce. */
+        addi s4, s4, 1
+        /* Compute A[i][j] * z[j] and set the output at index i. */
+        addi a0, s0, 0
+        addi a1, s1, 0
+        addi a2, s2, 0
+        jal  x1, poly_pointwise
+        addi s0, s0, 1024
+        loopi Lminus1, 10
             /* Compute A[i][j]. */
             addi a0, fp, STACK_RHO
             addi a1, s1, 0

--- a/sw/otbn/crypto/mldsa/mldsa_verify.s
+++ b/sw/otbn/crypto/mldsa/mldsa_verify.s
@@ -162,8 +162,14 @@
  *
  * Returns: 0 on success
  *
- * @param[in]  x10: zeta (random bytes)
- * @param[out] x10: 0 on success, -1 on failure
+ * @param[in] x10: *sig, pointer to signature in DMEM
+ * @param[in] x11: siglen, byte-length of signature
+ * @param[in] x12: *msg, pointer to message in DMEM
+ * @param[in] x13: msglen, byte-length of message
+ * @param[in] x14: *pk, pointer to public key in DMEM
+ * @param[in] x15: *ctx, pointer to context in DMEM
+ * @param[in] x16: ctxlen, byte-length of context
+ * @param[out] dmem[result]: 0 on success, 0xffffff on failure
  *
  */
 .globl crypto_sign_verify_internal
@@ -181,28 +187,28 @@ crypto_sign_verify_internal:
     #define STACK_CP   -1152 /* Prev - 1024 */
     #define STACK_TMP  -2176 /* Prev - 1024 */
 #if DILITHIUM_MODE == 2
-    #define STACK_T1  -6272 /* Prev - K*1024 */
-    #define STACK_C  -6304 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
-    #define STACK_Z  -10400 /* Prev - L*1024 */
-    #define STACK_H  -14496 /* Prev - K*1024 */
-    #define STACK_W1  -18592 /* Prev - K*1024 */
-    #define INIT_SP -18624
+    #define STACK_C  -2208 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
+    #define STACK_Z  -6304 /* Prev - L*1024 */
+    #define STACK_H  -10400 /* Prev - K*1024 */
+    #define STACK_W1  -14496 /* Prev - K*1024 */
+    #define INIT_SP -14496
+    #define STACK_SIZE 14624
 
 #elif DILITHIUM_MODE == 3
-    #define STACK_T1  -8320 /* Prev - K*1024 */
-    #define STACK_C  -8384 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
-    #define STACK_Z  -13504 /* Prev - L*1024 */
-    #define STACK_H  -19648 /* Prev - K*1024 */
-    #define STACK_W1  -25792 /* Prev - K*1024 */
-    #define INIT_SP -25824
+    #define STACK_C  -2240 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
+    #define STACK_Z  -7360 /* Prev - L*1024 */
+    #define STACK_H  -13504 /* Prev - K*1024 */
+    #define STACK_W1  -19648 /* Prev - K*1024 */
+    #define INIT_SP -19648
+    #define STACK_SIZE 19776
 
 #elif DILITHIUM_MODE == 5
-    #define STACK_T1  -10368 /* Prev - K*1024 */
-    #define STACK_C  -10432 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
-    #define STACK_Z  -17600 /* Prev - L*1024 */
-    #define STACK_H  -25792 /* Prev - K*1024 */
-    #define STACK_W1  -33984 /* Prev - K*1024 */
-    #define INIT_SP -34016
+    #define STACK_C  -2240 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
+    #define STACK_Z  -9408 /* Prev - L*1024 */
+    #define STACK_H  -17600 /* Prev - K*1024 */
+    #define STACK_W1  -25792 /* Prev - K*1024 */
+    #define INIT_SP -25792
+    #define STACK_SIZE 25920
 #endif
 
     /* Initialize the frame pointer */
@@ -246,18 +252,6 @@ crypto_sign_verify_internal:
     li     t1, STACK_RHO
     add    t1, fp, t1
     bn.sid t0, 0(t1)
-
-    /* Unpack t1 */
-    /* Load pointer to t1 */
-    li   a0, STACK_T1
-    add  a0, fp, a0
-    /* Load pointer to packed t1 */
-    addi a1, a4, 0
-
-    /* Store t1 */
-    LOOPI K, 2
-        jal x1, polyt1_unpack
-        nop
 
     /* Unpack sig */
     /* Unpack c */
@@ -569,43 +563,8 @@ crypto_sign_verify_internal:
         pop \reg
     .endr
 
-    /* shiftl(t1) */
-
-    /* Load t1 address */
-    li  a0, STACK_T1
-    add a0, fp, a0
-
-    /* Setup WDRs */
-    li t0, 0
-    li t1, 1
-
-    LOOPI K, 5
-        LOOPI 32, 3
-            bn.lid    t0, 0(a0)
-            bn.shv.8S w0, w0 << D
-            bn.sid    t0, 0(a0++)
-        nop /* Nested loops must not end on the same instruciton  */
 
     /* After NTT(c), w16 is still R | Q and MOD is still 2*R | 2*Q */
-    /* NTT(t1) */
-    li   a0, STACK_T1
-    add  a0, fp, a0
-    addi a2, a0, 0 /* inplace */
-    la   a1, twiddles_fwd
-
-    .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-        push \reg
-    .endr
-
-    LOOPI K, 2
-        jal  x1, ntt
-        addi a1, a1, -1024
-
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-        pop \reg
-    .endr
-
-    /* After NTT(t1), w16 is still R | Q and MOD is still 2*R | 2*Q */
 
     /* Load source pointers for matrix-vector multiplication. */
     li  s0, STACK_Z
@@ -671,6 +630,12 @@ crypto_sign_verify_internal:
     li  a1, CRHBYTES /* set mu length to CRHBYTES */
     jal x1, keccak_send_message
 
+    /* Load the pointer to the packed t1 within the public key. */
+    li   s6, STACK_PK
+    add  s6, fp, s6
+    lw   s6, 0(s6)
+    addi s6, s6, 32
+
     /* This loop computes w1 polynomials and sends them to the Keccak core
        incrementally. This way, we avoid ever storing the entire w1 on the
        stack. */
@@ -679,11 +644,28 @@ crypto_sign_verify_internal:
     add s1, fp, s1
     li  s2, STACK_H
     add s2, fp, s2
-    li  s3, STACK_T1
+    li  s3, STACK_TMP
     add s3, fp, s3
     li  s4, STACK_CP
     add s4, fp, s4
-    LOOPI K, 24
+    la  s5, twiddles_fwd
+    LOOPI K, 36
+        /* Unpack the next polynomial from t1 and store it in temp buffer. */
+        addi a0, s3, 0
+        addi a1, s6, 0
+        jal  x1, polyt1_unpack
+        addi s6, a1, 0
+        /* Shift-left of t1 polynomial. */
+        addi t1, s3, 0
+        LOOPI 32, 3
+            bn.lid    zero, 0(t1)
+            bn.shv.8S w0, w0 << D
+            bn.sid    zero, 0(t1++)
+        /* Compute ntt(t1) in place. */
+        addi a0, s3, 0
+        addi a1, s5, 0
+        addi a2, s3, 0
+        jal  x1, ntt
         /* Compute cp * t1, storing the result in t1. */
         addi a0, s4, 0
         addi a1, s3, 0
@@ -712,7 +694,6 @@ crypto_sign_verify_internal:
         addi a0, s1, 0
         addi a1, zero, POLYW1_PACKEDBYTES
         jal  x1, keccak_send_message
-        addi s3, s3, 1024 /* increment *t1 */
         addi s1, s1, 1024 /* increment *w1 */
 
     /* Setup WDR for c2 */

--- a/sw/otbn/crypto/mldsa/mldsa_verify.s
+++ b/sw/otbn/crypto/mldsa/mldsa_verify.s
@@ -189,26 +189,18 @@ crypto_sign_verify_internal:
 #if DILITHIUM_MODE == 2
     #define STACK_C  -2208 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
     #define STACK_Z  -6304 /* Prev - L*1024 */
-    #define STACK_H  -10400 /* Prev - K*1024 */
-    #define STACK_W1  -14496 /* Prev - K*1024 */
-    #define INIT_SP -14496
-    #define STACK_SIZE 14624
-
+    #define STACK_W1  -10400 /* Prev - K*1024 */
+    #define INIT_SP -10400
 #elif DILITHIUM_MODE == 3
     #define STACK_C  -2240 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
     #define STACK_Z  -7360 /* Prev - L*1024 */
-    #define STACK_H  -13504 /* Prev - K*1024 */
-    #define STACK_W1  -19648 /* Prev - K*1024 */
-    #define INIT_SP -19648
-    #define STACK_SIZE 19776
-
+    #define STACK_W1  -13504 /* Prev - K*1024 */
+    #define INIT_SP -13504
 #elif DILITHIUM_MODE == 5
     #define STACK_C  -2240 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
     #define STACK_Z  -9408 /* Prev - L*1024 */
-    #define STACK_H  -17600 /* Prev - K*1024 */
-    #define STACK_W1  -25792 /* Prev - K*1024 */
-    #define INIT_SP -25792
-    #define STACK_SIZE 25920
+    #define STACK_W1  -17600 /* Prev - K*1024 */
+    #define INIT_SP -17600
 #endif
 
     /* Initialize the frame pointer */
@@ -298,23 +290,8 @@ crypto_sign_verify_internal:
         jal x1, polyz_unpack
         nop
 
-    /* Decode h */
-
-    /* Load pointer to h */
-    li  a0, STACK_H
-    add a0, fp, a0
-
-    .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-        push \reg
-    .endr
-
-    jal x1, polyvec_decode_h
-    /* Raise error */
-    bne a0, zero, _fail_crypto_sign_verify_internal
-
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-        pop \reg
-    .endr
+    /* Copy sig pointer for unpacking h later. */
+    addi s9, a1, 0
 
     /* reduce32(z) for central representation */
     li  a0, STACK_Z
@@ -636,20 +613,22 @@ crypto_sign_verify_internal:
     lw   s6, 0(s6)
     addi s6, s6, 32
 
+    /* Initialize the counters for poly_decode_h. */
+    li   s7, 0
+    li   s8, 0
+
     /* This loop computes w1 polynomials and sends them to the Keccak core
        incrementally. This way, we avoid ever storing the entire w1 on the
        stack. */
     la  s0, twiddles_inv
     li  s1, STACK_W1
     add s1, fp, s1
-    li  s2, STACK_H
-    add s2, fp, s2
     li  s3, STACK_TMP
     add s3, fp, s3
     li  s4, STACK_CP
     add s4, fp, s4
     la  s5, twiddles_fwd
-    LOOPI K, 36
+    .rept K
         /* Unpack the next polynomial from t1 and store it in temp buffer. */
         addi a0, s3, 0
         addi a1, s6, 0
@@ -680,12 +659,21 @@ crypto_sign_verify_internal:
         addi a0, s1, 0
         addi a1, s0, 0
         jal  x1, intt
+        /* Decode the next polynomial from the hint, failing on error. */
+        addi a0, s3, 0
+        addi a1, s9, 0
+        addi a2, s7, 0
+        addi a3, s8, 0
+        jal x1, poly_decode_h
+        bne a4, zero, _fail_crypto_sign_verify_internal
+        addi s9, a1, 0
+        addi s7, a2, 0
+        addi s8, a3, 0
         /* Use the hint to compute the next w1 polynomial. */
         addi a0, s1, 0
         addi a1, s1, 0
-        addi a2, s2, 0
+        addi a2, s3, 0
         jal  x1, poly_use_hint
-        addi s2, a2, 0
         /* Pack the w1 polynomial (in-place). */
         addi a0, s1, 0
         addi a1, s1, 0
@@ -695,6 +683,7 @@ crypto_sign_verify_internal:
         addi a1, zero, POLYW1_PACKEDBYTES
         jal  x1, keccak_send_message
         addi s1, s1, 1024 /* increment *w1 */
+    .endr
 
     /* Setup WDR for c2 */
     li t1, 8

--- a/sw/otbn/crypto/mldsa/mldsa_verify.s
+++ b/sw/otbn/crypto/mldsa/mldsa_verify.s
@@ -194,16 +194,19 @@ crypto_sign_verify_internal:
     #define STACK_Z  -6304 /* Prev - L*1024 */
     #define STACK_W1  -10400 /* Prev - K*1024 */
     #define INIT_SP -10400
+    #define STACK_SIZE 10528 /* Expected stack size for reference (unused). */
 #elif DILITHIUM_MODE == 3
     #define STACK_C  -2240 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
     #define STACK_Z  -7360 /* Prev - L*1024 */
     #define STACK_W1  -13504 /* Prev - K*1024 */
     #define INIT_SP -13504
+    #define STACK_SIZE 13632 /* Expected stack size for reference (unused). */
 #elif DILITHIUM_MODE == 5
     #define STACK_C  -2240 /* Prev - K*ceil(CTILDEBYTES/32)*32 */
     #define STACK_Z  -9408 /* Prev - L*1024 */
     #define STACK_W1  -17600 /* Prev - K*1024 */
     #define INIT_SP -17600
+    #define STACK_SIZE 17728 /* Expected stack size for reference (unused). */
 #endif
 
     /* Initialize the frame pointer */

--- a/sw/otbn/crypto/mldsa/mldsa_verify.s
+++ b/sw/otbn/crypto/mldsa/mldsa_verify.s
@@ -659,56 +659,6 @@ crypto_sign_verify_internal:
         addi a2, a2, 1024
     .endr
 
-    /* After poly_pointwise, w16 is still R | Q and MOD is still 2*R | 2*Q */
-    /* t1 = cp * t1 */
-    li  a0, STACK_CP
-    add a0, fp, a0
-    li  a1, STACK_T1
-    add a1, fp, a1
-    li  a2, STACK_T1
-    add a2, fp, a2
-
-    LOOPI K, 2
-        jal  x1, poly_pointwise
-        addi a0, a0, -1024
-
-    /* MOD is still 2*R | 2*Q, but since w1 and t1 are both in [0,2q), w1 - t1 mod 2q is still in
-     * [0,2q), which is fine as input to INTT right after. So we don't need to switch MOD back to q */
-    /* w1 = w1 - t1 */
-    li  a0, STACK_W1
-    add a0, fp, a0
-    li  a1, STACK_T1
-    add a1, fp, a1
-    li  a2, STACK_W1
-    add a2, fp, a2
-
-    LOOPI K, 2
-        jal x1, poly_sub
-        nop
-
-    /* After poly_sub, w16 is still R | Q and MOD is still 2*R | 2*Q */
-    /* Inverse NTT on w1 */
-    li  a0, STACK_W1
-    add a0, fp, a0
-    la  a1, twiddles_inv
-
-    .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-        push \reg
-    .endr
-
-    LOOPI K, 3
-        jal  x1, intt
-        /* Reset the twiddle pointer */
-        addi a1, a1, -960
-        /* Go to next input polynomial */
-        addi a0, a0, 1024
-
-    bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
-
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-        pop \reg
-    .endr
-
     /* Call random oracle and verify challenge */
     /* Initialize a SHAKE256 operation. */
     li a1, CRHBYTES
@@ -727,11 +677,30 @@ crypto_sign_verify_internal:
     /* This loop computes w1 polynomials and sends them to the Keccak core
        incrementally. This way, we avoid ever storing the entire w1 on the
        stack. */
+    la  s0, twiddles_inv
     li  s1, STACK_W1
     add s1, fp, s1
     li  s2, STACK_H
     add s2, fp, s2
-    LOOPI K, 13
+    li  s3, STACK_T1
+    add s3, fp, s3
+    li  s4, STACK_CP
+    add s4, fp, s4
+    LOOPI K, 24
+        /* Compute cp * t1, storing the result in t1. */
+        addi a0, s4, 0
+        addi a1, s3, 0
+        addi a2, s3, 0
+        jal  x1, poly_pointwise
+        /* Compute the next polynomial of w_approx = Az - t1. */
+        addi a0, s1, 0
+        addi a1, s3, 0
+        addi a2, s1, 0
+        jal x1, poly_sub
+        /* Inverse NTT on w_approx (stored in w1 buffer). */
+        addi a0, s1, 0
+        addi a1, s0, 0
+        jal  x1, intt
         /* Use the hint to compute the next w1 polynomial. */
         addi a0, s1, 0
         addi a1, s1, 0
@@ -744,10 +713,10 @@ crypto_sign_verify_internal:
         jal  x1, polyw1_pack
         /* Send the packed w1 polynomial to the Keccak core. */
         addi a0, s1, 0
-        addi s1, a1, 0 /* increment *w1 */
         addi a1, zero, POLYW1_PACKEDBYTES
         jal  x1, keccak_send_message
-        nop
+        addi s3, s3, 1024 /* increment *t1 */
+        addi s1, s1, 1024 /* increment *w1 */
 
     /* Setup WDR for c2 */
     li t1, 8

--- a/sw/otbn/crypto/mldsa/poly.s
+++ b/sw/otbn/crypto/mldsa/poly.s
@@ -1569,6 +1569,9 @@ poly_nonzero_encode:
  * Bit-pack polynomial w1 with coefficients fitting in 6 bits. Input
  * coefficients are assumed to be standard representatives.
  *
+ * Output and input buffers may not arbitrarily overlap, but they may be the
+ * same.
+ *
  * Flags: -
  *
  * @param[out] a0: pointer to output byte array with at least

--- a/sw/otbn/crypto/mldsa/poly.s
+++ b/sw/otbn/crypto/mldsa/poly.s
@@ -271,7 +271,7 @@ polyz_unpack:
     bn.lid t2, 0(t3)
 
     /* Load mask for zeroing the upper bits of the unpacked coefficients. */
-    li t2, 5
+    li t5, 5
     la t3, polyz_unpack_mask
     bn.lid t5, 0(t3)
 
@@ -370,7 +370,7 @@ _inner_polyz_unpack:
     bn.lid t2, 0(t3)
 
     /* Load mask for zeroing the upper bits of the unpacked coefficients. */
-    li t2, 5
+    li t5, 5
     la t3, polyz_unpack_mask
     bn.lid t5, 0(t3)
 

--- a/sw/otbn/crypto/mldsa/poly.s
+++ b/sw/otbn/crypto/mldsa/poly.s
@@ -1772,40 +1772,45 @@ _inner_polyeta_unpack:
         bn.sid t2, 0(a0++)
     ret
 #endif
+
+
 /**
- * polyvec_decode_h
+ * poly_decode_h
  *
- * Decode h from signature into polyvec h. Check extra indices.
+ * Decode a single polynomial of the hint from the signature. Returns 1 on a
+ * decode failure, or 0 on success. Increments input pointer and indices for
+ * the next call to the same function (but not output pointer). If the index
+ * indicates that this is the last hint polynomial, then checks that extra bits
+ * are zero.
  *
  * Flags: -
  *
- * @param[in]  a1: pointer to input byte array signature
- * @param[out] a0: pointer to output polynomial h
+ * @param[in]  a0: pointer to output polynomial h
+ * @param[in]  a1: pointer to bytes of encoded hint
+ * @param[in]  a2: k, number of nonzero h coefficients so far
+ * @param[in]  a3: i, index of this polynomial in h
+ * @param[out] a4: return code (1 or 0)
  *
  * clobbered registers: a0-a7, t0-t6
  */
-.global polyvec_decode_h
-polyvec_decode_h:
-    /* Initialize h to zero */
+.global poly_decode_h
+poly_decode_h:
+    /* Initialize h[i] to zero */
     add t1, zero, a0
     li t0, 31
     LOOPI 32, 1
         bn.sid t0, 0(t1++)
 
-    li t0, 0 /* "k" = 0 */
-    li t1, 0 /* "i" = 0 */
     /* Initialize constants */
     li t4, OMEGA
-    li a2, 0xFFFFFFFC
     li a7, 1
 
     /* The notation inside the comments goes in line with the reference code */
-_loop_decode_h:
     /* Load sig[OMEGA + i] to t2 */
-    addi t2, t1, OMEGA /* i + OMEGA */
+    addi t2, a3, OMEGA /* i + OMEGA */
     add  t6, t2, a1    /* (sig + OMEGA + i) */
-    andi  a4, t6, 0x3   /* get lower two bits */
-    and  t6, t6, a2    /* set lowest two bits to 0 */
+    andi a4, t6, 0x3   /* get lower two bits */
+    sub  t6, t6, a4    /* set lowest two bits to 0 */
     lw   t6, 0(t6)     /* aligned load */
     slli a4, a4, 3
     srl  t6, t6, a4    /* extract the respective byte */
@@ -1814,7 +1819,7 @@ _loop_decode_h:
     /* Note: sig, k, OMEGA are all unsigned. Can also compare by subtracting and
        checking the MSB */
     /* sig[OMEGA + i] <? k  */
-    sub t3, t2, t0
+    sub t3, t2, a2
     srli t3, t3, 31
     bne t3, zero, _ret1_decode_h
     /* || sig[OMEGA + i] >? OMEGA */
@@ -1822,7 +1827,7 @@ _loop_decode_h:
     srli t3, t3, 31
     bne t3, zero, _ret1_decode_h
 
-    addi t5, t0, 0 /* j = k */
+    addi t5, a2, 0 /* j = k */
 
     /* Check if there is nothing to do if k = sig[OMEGA + i] */
     beq t2, t5, _loop_inner_skip_decode_h
@@ -1831,7 +1836,7 @@ _loop_decode_h:
     /* Load sig[j] */
     add  t6, t5, a1   /* (sig + j) */
     andi a4, t6, 0x3  /* get lower two bits */
-    and  t6, t6, a2   /* set lowest two bits to 0 */
+    sub  t6, t6, a4   /* set lowest two bits to 0 */
     lw   t6, 0(t6)    /* aligned load */
     slli a4, a4, 3
     srl  t6, t6, a4   /* extract the respective byte */
@@ -1851,17 +1856,17 @@ _loop_inner_decode_h:
         /* Load sig[j] */
         add  a5, t5, a1  /* (sig + j) */
         andi a4, a5, 0x3 /* get lower two bits */
-        and  t6, a5, a2  /* set lowest two bits to 0 */
-        lw   a3, 0(t6)   /* aligned load */
+        sub  t6, a5, a4  /* set lowest two bits to 0 */
+        lw   t1, 0(t6)   /* aligned load */
         slli a4, a4, 3
-        srl  a3, a3, a4  /* extract the respective byte */
-        andi a3, a3, 0xFF
+        srl  t1, t1, a4  /* extract the respective byte */
+        andi t1, t1, 0xFF
 
         /* sig[j - 1] is in a6 at this point */
 
         /* sig[j] ==? sig[j-1] */
-        beq  a3, a6, _ret1_decode_h
-        sub t6, a3, a6
+        beq  t1, a6, _ret1_decode_h
+        sub t6, t1, a6
         srli t6, t6, 31
 
         /* sig[j] <? sig[j-1] */
@@ -1869,7 +1874,7 @@ _loop_inner_decode_h:
         beq t6, a4, _ret1_decode_h
 
 
-        slli a4, a3, 2  /* sig[j] * 4 */
+        slli a4, t1, 2  /* sig[j] * 4 */
         add  t6, a0, a4 /* (h[sig[j]]) */
         sw   a7, 0(t6)  /* h->vec[i].coeffs[sig[j]] = 1 */
 
@@ -1881,22 +1886,22 @@ _loop_inner_decode_h:
         bne t5, t2, _loop_inner_decode_h
 _loop_inner_skip_decode_h:
 
-    addi t0, t2, 0    /* k = sig[OMEGA + i]; */
-    addi t1, t1, 1    /* i++ */
-    addi a0, a0, 1024 /* Go to next poly in h */
+    addi a2, t2, 0    /* k = sig[OMEGA + i]; */
+    addi a3, a3, 1    /* i++ */
+
+    /* Check if this is the last polynomial. */
     li   t5, K
+    bne  a3, t5, _ret0_decode_h
 
-    /* i <? 4 (K = 4): Check if all polynomials are done */
-    bne t1, t5, _loop_decode_h
+    /* Ensure the extra indices are 0. */
 
-    /* Extra indices zero  */
-    addi t5, t0, 0 /* j = k */
+    addi t5, a2, 0 /* j = k */
     beq  t5, t4, _ret0_decode_h
 _loop_extra_decode_h:
     /* Load sig[j] */
     add  t6, t5, a1   /* (sig + j) */
     andi a4, t6, 0x3  /* get lower two bits */
-    and  t6, t6, a2   /* set lowest two bits to 0 */
+    sub  t6, t6, a4   /* set lowest two bits to 0 */
     lw   t6, 0(t6)    /* aligned load */
     slli a4, a4, 3
     srl  t6, t6, a4   /* extract the respective byte */
@@ -1909,11 +1914,11 @@ _loop_extra_decode_h:
     bne  t5, t4, _loop_extra_decode_h
 
 _ret0_decode_h:
-    li a0, 0
+    li a4, 0
     ret
 
 _ret1_decode_h:
-    li a0, 1
+    li a4, 1
     ret
 
 /**

--- a/sw/otbn/crypto/tests/mldsa/mldsa_verify_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_verify_test.s
@@ -12,11 +12,11 @@
 
 .section .text.start
 #if DILITHIUM_MODE == 2
-    #define STACK_SIZE 18752
+    #define STACK_SIZE 14624
 #elif DILITHIUM_MODE == 3
-    #define STACK_SIZE 25952
+    #define STACK_SIZE 19776
 #elif DILITHIUM_MODE == 5
-    #define STACK_SIZE 34144
+    #define STACK_SIZE 25920
 #endif
 
 #define CTXLEN 32

--- a/sw/otbn/crypto/tests/mldsa/mldsa_verify_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_verify_test.s
@@ -11,7 +11,13 @@
 */
 
 .section .text.start
-#define STACK_SIZE 112000
+#if DILITHIUM_MODE == 2
+    #define STACK_SIZE 18752
+#elif DILITHIUM_MODE == 3
+    #define STACK_SIZE 25952
+#elif DILITHIUM_MODE == 5
+    #define STACK_SIZE 34144
+#endif
 
 #define CTXLEN 32
 

--- a/sw/otbn/crypto/tests/mldsa/mldsa_verify_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_verify_test.s
@@ -12,11 +12,11 @@
 
 .section .text.start
 #if DILITHIUM_MODE == 2
-    #define STACK_SIZE 14624
+    #define STACK_SIZE 10528
 #elif DILITHIUM_MODE == 3
-    #define STACK_SIZE 19776
+    #define STACK_SIZE 13632
 #elif DILITHIUM_MODE == 5
-    #define STACK_SIZE 25920
+    #define STACK_SIZE 17728
 #endif
 
 #define CTXLEN 32


### PR DESCRIPTION
With this set of changes, the total DMEM requirements for ML-DSA-87 verify (as checked by looking for the `dmem_end` symbol on the test) is about 31kB. Unlike with signing, there's no need to go lower than that, since verify doesn't require masking.

Here are some summary statistics compared with the version of verification before any memory optimizations (just spot-checks using the existing tests, not proper high-sample-size benchmarks):

```
ML-DSA-44 verify test: 130955 -> 131376 cycles (+0.32%)
ML-DSA-65 verify test: 215996 -> 216786 cycles (+0.37%)
ML-DSA-87 verify test: 364978 -> 366139 cycles (+0.32%)
```

The performance impact is consistent across parameter sets and very small, which makes sense since most data structures in verification are only processed once and streaming them incurs a small amount of bookkeeping overhead but not any duplication of long steps.

Note that some of the rearrangements of verification checks (in particular the one in this commit, which moves the decoding of h much later) will cause invalid signatures to get rejected more slowly, even though they do not strongly affect performance for valid signatures.

The cycle counts are from a branch that was based on #32, so if this PR is merged before that one the numbers might not match. I will try to remember to update the counts before merging depending on the merge order.