### PR TITLE
[otbn] Fixed otbnsim error with model not flushing KMAC partial writes for small message sizes

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -591,7 +591,7 @@ class CSRRW(OTBNInsn):
             # to the AppIntf FIFO inside OTBN Bignum ALU
             if DEBUG_KMAC:
                 eprint("\tBNWSRW FOR KMAC PARTIAL WRITE REGISTER")
-            while state.wsrs.KMAC_MSG.pending_write():
+            while state.wsrs.KMAC_MSG.pending_write_pw():
                 if DEBUG_KMAC:
                     eprint("\tBNWSRW to KMAC_PW stall")
                 yield None

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -436,6 +436,7 @@ class KmacBlock:
         self._app_intf_fifo_ready = True
         self._app_intf_fifo_ready_next = True
         self._app_intf_fifo_flush = False
+        self._app_fifo_after_flush = False
         self._pending_app_intf_last = False
         self._app_intf_last = False
         self._app_intf_last_latch = False
@@ -480,6 +481,7 @@ class KmacBlock:
         self._app_intf_fifo_ready = True
         self._app_intf_fifo_ready_next = True
         self._app_intf_fifo_flush = False
+        self._app_fifo_after_flush = False
         self._core_pending_bytes = 0
         self._core_pending_bytes_next = 0
         self._msg_len = 0
@@ -513,6 +515,7 @@ class KmacBlock:
         self._app_intf_bytes_sent = 0
         self._app_intf_ready_pending_ctr = 0
         self._app_intf_last_latch = False
+        self._app_fifo_after_flush = False
         # Reset error flags
         self._kmac_undersized_err = False
         self._kmac_oversized_err = False
@@ -720,9 +723,11 @@ class KmacBlock:
                         ready = {self.app_intf_fifo_ready()}, \
                         fifo len = {len(self._app_intf_fifo)}")
         # If there is more than 8B we can not yet write
+        # When the FIFO is flushing it is illegal to write to
         if (
             not self.app_intf_fifo_ready()
             or len(self._app_intf_fifo) > self._APP_INTF_BYTES_PER_CYCLE
+            or self._app_intf_fifo_flush
         ):
             return False
         self._app_intf_fifo += msg
@@ -915,6 +920,7 @@ class KmacBlock:
                 self._msg_len -= nbytes
                 self._app_intf_bytes_sent += nbytes
                 self._app_intf_fifo_flush = False
+                self._app_fifo_after_flush = True
                 self._app_intf_sending = True
 
             # Flushing the APP FIFO has an extra clock cycle to read
@@ -926,6 +932,7 @@ class KmacBlock:
                 if (len(self._app_intf_fifo) < 8):
                     # Flushing the APP FIFO has an extra clock cycle to read
                     self._app_intf_fifo_flush = True
+                    kmac_debug_print("FLUSHING APP INTF")
                 else:
                     # This is an oversized message and has filled the next
                     # word therefore no etra flush cycle
@@ -1142,6 +1149,8 @@ class KmacMsgWSR(WSR):
         kmac_debug_print("\tFETCHING STARTING FIFO STATUS")
         self._pending_write_stall_pw = self._pending_write_to_app_intf
         self._start_cycle_fifo_ready = self._kmac.app_intf_fifo_ready()
+        if self._kmac._app_fifo_after_flush:
+            self._pending_write_stall_pw = False
         # KMAC_MSG reg -> FIFO
         if self._pending_write_to_app_intf:
             strb_len = self._partial_ispr.read_mask()
@@ -1149,8 +1158,8 @@ class KmacMsgWSR(WSR):
             kmac_debug_print("\tPending write to App FIFO")
             if (
                 self._kmac._app_intf_last_latch
-                or (self._kmac._pending_app_intf_last and not self.pending_write())
-                or self._kmac._app_intf_fifo_flush
+                or (self._kmac._pending_app_intf_last and not self.pending_write_pw())
+                and not self._kmac._app_intf_fifo_flush
             ):
                 kmac_debug_print("DROPPING WRITE TO FIFO FROM OVERSIZED MSG")
                 self._pending_write_to_app_intf = False
@@ -1161,8 +1170,11 @@ class KmacMsgWSR(WSR):
                 self._pending_write_to_app_intf = False
                 self._kmac._app_intf_writing = True
 
-    def pending_write(self) -> bool:
-        return self._pending_write_stall_pw or self._kmac._app_intf_fifo_flush
+    def pending_write_pw(self) -> bool:
+        if self._kmac._app_intf_fifo_flush and not self._pending_write_to_app_intf:
+            return False
+        else:
+            return self._pending_write_stall_pw
 
     def request_write(self) -> bool:
         return self._start_cycle_fifo_ready

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_load_store.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_load_store.py
@@ -242,6 +242,7 @@ class BadLoadStore(SnippetGen):
                     if val < max_offset:
                         tgt_addr = random.randrange(val + min_offset, -1, 32)
                         bn_imm_val = tgt_addr - val
+                        break
 
         # Check if the final target address is in OOB region
         assert bn_imm_val + val < 0 or bn_imm_val + val >= model.dmem_size

--- a/hw/ip/otbn/dv/uvm/otbn_app_agent/otbn_app_base_seq.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_app_agent/otbn_app_base_seq.sv
@@ -286,7 +286,7 @@ class otbn_app_base_seq extends dv_base_seq #(
 
               // With 1B or less the packer absorb will ocurr during ongoing run if required
               end else begin
-                flush_ctr += ((kmac_msg_fifo_cnt % 8) > 0) ? 1 : 0;
+                flush_ctr += (kmac_msg_fifo_cnt > 0) ? 1 : 0;
                 flush_in_absorb = 1;
               end
             end


### PR DESCRIPTION
This PR fixes a small bug in the `otbn_app_base_seq.sv` with an incorrect logical statement using a modulo where a remaining message size of 0 Bytes and 8 Bytes were being interpreted the same for the computation of the MSG FIFO flush delay. The 0 Bytes size was being correctly handled without a flush delay, but the 8 Bytes message size had an unintentional clock cycle delay.

`- flush_ctr += ((kmac_msg_fifo_cnt % 8) > 0) ? 1 : 0;`
`+ flush_ctr += (kmac_msg_fifo_cnt > 0) ? 1 : 0;`

A second small bug was found in the `wsr.py` file of otbnsim where the ISS was stalling during an oversized message while the DUT was dropping the oversized message writes. When the original message length was less than 8 Bytes, but the actual message was chosen to oversized by the generator, the App FIFO would flush on the first clock cycle. This also meant that there was no outstanding write for a second message before a partial write instruction would occur. In hardware, this was safe to drop the partial write and continue execution. In `otbnsim` the ISS was stalling the partial write during the flush cycle instead of dropping it. The ISS has been updated to more precisely model the App FIFO flushing and outstanding write behavior. In most other test cases there was a pending write to the AppIntf which was blocking the execution of the partial write.

Additionally, it adds a missing break statement to the `bad_load_store.py` loop that resulting in updating the register index and value after setting a new target address and immediate offset.