### PR TITLE
[mldsa] Memory optimizations for key generation.

### DIFF
--- a/sw/otbn/crypto/mldsa/mldsa_keypair.s
+++ b/sw/otbn/crypto/mldsa/mldsa_keypair.s
@@ -180,39 +180,34 @@ crypto_sign_keypair:
     #define STACK_PK_ADDR -164
     #define STACK_SK_ADDR -168
     #define STACK_TR      -256
+    #define STACK_TMP    -1280 /* Prev - 1024 */
 #if DILITHIUM_MODE == 2
-    #define STACK_MAT -16640 /* Prev - K*L*1024 */
-    #define STACK_S1  -20736 /* Prev - L*1024 */
-    #define STACK_S2  -24832 /* Prev - K*1024 */
-    #define STACK_T1  -28928 /* Prev - K*1024 */
-    #define STACK_T0  -33024 /* Prev - K*1024 */
-    #define STACK_S1_HAT  -37120 /* Prev - L*1024 */
+    #define STACK_S1  -5376 /* Prev - L*1024 */
+    #define STACK_S2  -9472 /* Prev - K*1024 */
+    #define STACK_T1  -13568 /* Prev - K*1024 */
+    #define STACK_T0  -17664 /* Prev - K*1024 */
+    #define STACK_S1_HAT  -21760 /* Prev - L*1024 */
+    #define INIT_SP -21760
 #elif DILITHIUM_MODE == 3
-    #define STACK_MAT -30976 /* Prev - K*L*1024 */
-    #define STACK_S1  -36096 /* Prev - L*1024 */
-    #define STACK_S2  -42240 /* Prev - K*1024 */
-    #define STACK_T1  -48384 /* Prev - K*1024 */
-    #define STACK_T0  -54528 /* Prev - K*1024 */
-    #define STACK_S1_HAT  -59648 /* Prev - L*1024 */
+    #define STACK_S1  -6400 /* Prev - L*1024 */
+    #define STACK_S2  -12544 /* Prev - K*1024 */
+    #define STACK_T1  -18688 /* Prev - K*1024 */
+    #define STACK_T0  -24832 /* Prev - K*1024 */
+    #define STACK_S1_HAT  -29952 /* Prev - L*1024 */
+    #define INIT_SP -29952
 #elif DILITHIUM_MODE == 5
-    #define STACK_MAT -57600 /* Prev - K*L*1024 */
-    #define STACK_S1  -64768 /* Prev - L*1024 */
-    #define STACK_S2  -72960 /* Prev - K*1024 */
-    #define STACK_T1  -81152 /* Prev - K*1024 */
-    #define STACK_T0  -89344 /* Prev - K*1024 */
-    #define STACK_S1_HAT  -96512 /* Prev - L*1024 */
+    #define STACK_S1  -8448 /* Prev - L*1024 */
+    #define STACK_S2  -16640 /* Prev - K*1024 */
+    #define STACK_T1  -24832 /* Prev - K*1024 */
+    #define STACK_T0  -33024 /* Prev - K*1024 */
+    #define STACK_S1_HAT  -40192 /* Prev - L*1024 */
+    #define INIT_SP -40192
 #endif
     /* Initialize the frame pointer */
     addi fp, sp, 0
 
     /* Reserve space on the stack */
-#if DILITHIUM_MODE == 2
-    li  t0, -37120
-#elif DILITHIUM_MODE == 3
-    li  t0, -59648
-#elif DILITHIUM_MODE == 5
-    li  t0, -96512
-#endif
+    li  t0, INIT_SP
     add sp, sp, t0
 
     /* Store parameters to stack */
@@ -263,24 +258,6 @@ crypto_sign_keypair:
         bn.sid  t0, 0(t1++) /* Store into buffer */
 
     /* Finish the SHAKE-256 operation. */
-
-    /* Expand matrix */
-
-    /* Initialize the nonce */
-    li a2, 0
-
-    li a1, STACK_MAT
-    add a1, fp, a1
-    LOOPI K, 10
-        LOOPI L, 7
-            /* Load parameters */
-            addi a0, fp, STACK_RHO
-            push a2
-            jal  x1, poly_uniform
-            pop  a2
-            addi a2, a2, 1
-        addi a2, a2, 256
-        addi a2, a2, -L
 
     /* Sample s1 */
 
@@ -337,33 +314,55 @@ crypto_sign_keypair:
     .endr
 
     /* After NTT, w16 is still R | Q and MOD is still 2*R | 2*Q */
-    /* Matrix-vector multiplication */
 
-    /* Load source pointers */
-    li  a0, STACK_S1_HAT
-    add a0, fp, a0
-    li  a1, STACK_MAT
-    add a1, fp, a1
+    /* Load source pointers for matrix-vector multiplication. */
+    li  s0, STACK_S1_HAT
+    add s0, fp, s0
+    li  s1, STACK_TMP
+    add s1, fp, s1
 
-    /* Load destination pointer */
-    li  a2, STACK_T1
-    add a2, fp, a2
+    /* Load destination pointer for matrix-vector multiplication. */
+    li  s2, STACK_T1
+    add s2, fp, s2
 
-    /* Load offset for resetting pointer */
-    li s1, POLYVECL_BYTES
+    /* Zero the destination buffer. */
+    li t0, 31
+    addi t1, s2, 0
+    LOOPI K, 3
+        LOOPI 32, 1
+          bn.sid t0, 0(t1++)
+        nop
 
-    .rept K
-        jal  x1, poly_pointwise
-        addi a2, a2, -1024
+    /* Load offset for resetting vector pointer. */
+    li s3, POLYVECL_BYTES
 
-        .rept L-1
+    /* Initialize the nonce for matrix expansion. This value should be
+         byte(i) || byte(j)
+       for entry A[i][j]. */
+    li s4, 0
+
+     /* Compute A * s1, computing elements of A on the fly. */
+    loopi K, 15
+        loopi L, 10
+            /* Compute A[i][j]. */
+            addi a0, fp, STACK_RHO
+            addi a1, s1, 0
+            addi a2, s4, 0
+            jal  x1, poly_uniform
+            /* Increment the matrix nonce. */
+            addi s4, s4, 1
+            /* Compute A[i][j] * s1[j] and add it to the output at index i. */
+            addi a0, s0, 0
+            addi a1, s1, 0
+            addi a2, s2, 0
             jal  x1, poly_pointwise_acc
-            addi a2, a2, -1024
-        .endr
-
-        sub  a0, a0, s1   /* Reset input vector pointer */
-        addi a2, a2, 1024 /* Write next output polynomial */
-    .endr
+            addi s0, s0, 1024
+        /* Reset input vector pointer */
+        sub  s0, s0, s3
+        addi s2, s2, 1024
+        /* Adjust the matrix nonce to reset the column and increment the row. */
+        addi s4, s4, 256
+        addi s4, s4, -L
 
     /* After poly_pointwise, w16 is still R | Q and MOD is still 2*R | 2*Q */
     /* Inverse NTT on t1 */

--- a/sw/otbn/crypto/mldsa/mldsa_keypair.s
+++ b/sw/otbn/crypto/mldsa/mldsa_keypair.s
@@ -172,13 +172,13 @@ crypto_sign_keypair:
     #define STACK_TMP    -1280 /* Prev - 1024 */
     #define STACK_S1     -2304 /* Prev - 1024 */
 #if DILITHIUM_MODE == 2
-    #define STACK_T1  -6400 /* Prev - K*1024 */
+    #define STACK_T -6400 /* Prev - K*1024 */
     #define INIT_SP -6400
 #elif DILITHIUM_MODE == 3
-    #define STACK_T1  -8448 /* Prev - K*1024 */
+    #define STACK_T -8448 /* Prev - K*1024 */
     #define INIT_SP -8448
 #elif DILITHIUM_MODE == 5
-    #define STACK_T1  -10496 /* Prev - K*1024 */
+    #define STACK_T -10496 /* Prev - K*1024 */
     #define INIT_SP -10496
 #endif
     /* Initialize the frame pointer */
@@ -248,7 +248,7 @@ crypto_sign_keypair:
     add s1, fp, s1
 
     /* Load destination pointer for matrix-vector multiplication. */
-    li  s2, STACK_T1
+    li  s2, STACK_T
     add s2, fp, s2
 
     /* Zero the destination buffer. */
@@ -287,7 +287,7 @@ crypto_sign_keypair:
          for j in 0..l-1:
            s1j = ntt(s1[j])
            for i in 0..k-1:
-             out[i] += A[i][j] * s1j
+             t[i] += A[i][j] * s1j
     */
     loopi L, 29
         bn.wsrw   mod, w16 /* MOD = R | Q */
@@ -321,7 +321,7 @@ crypto_sign_keypair:
             addi a1, s1, 0
             addi a2, s2, 0
             jal  x1, poly_pointwise_acc
-            /* Increment the output vector pointer. */
+            /* Increment the output vector pointer *t. */
             addi s2, s2, 1024
         /* Reset output vector pointer. */
         sub  s2, s2, s3
@@ -331,8 +331,8 @@ crypto_sign_keypair:
         andi s4, s4, 255
 
     /* After poly_pointwise, w16 is still R | Q and MOD is still 2*R | 2*Q */
-    /* Inverse NTT on t1 */
-    li  a0, STACK_T1
+    /* Inverse NTT on t=A*s1 */
+    li  a0, STACK_T
     add a0, fp, a0
     la  a1, twiddles_inv
 
@@ -345,13 +345,13 @@ crypto_sign_keypair:
     /* Load pointers for loop. */
     li  s0, STACK_TMP
     add s0, fp, s0
-    li  s1, STACK_T1
+    li  s1, STACK_T
     add s1, fp, s1
 
     /* Initialize the nonce for sampling s2. */
     li s6, L
 
-    /* This loop samples s2 and adds it to A*s1 (currently in the t1 buffer). */
+    /* This loop samples s2 and adds it to A*s1 (currently in the t buffer). */
     LOOPI K, 14
         /* Sample the next polynomial from s2 and store in temp buffer. */
         addi a0, fp, STACK_RHOPRIME
@@ -369,15 +369,15 @@ crypto_sign_keypair:
         addi a1, s1, 0
         addi a2, s1, 0
         jal  x1, poly_add
-        /* Increment polyvec pointer. */
+        /* Increment polyvec pointer *t. */
         addi s1, s1, 1024
 
-    /* Reset t1 pointer for power2round loop. */
-    li  s1, STACK_T1
+    /* Reset t pointer for power2round loop. */
+    li  s1, STACK_T
     add s1, fp, s1
 
     LOOPI K, 9
-        /* Split t polynomial into t0 (tmp buffer) and t1 (t1 buffer). */
+        /* Split t polynomial into t0 (tmp buffer) and t1 (t buffer). */
         addi a0, s1, 0
         addi a1, s0, 0
         addi a2, s1, 0
@@ -387,7 +387,7 @@ crypto_sign_keypair:
         addi a1, s0, 0
         jal  x1, polyt0_pack
         addi s7, a0, 0
-        /* Increment polyvec pointer. */
+        /* Increment polyvec pointer *t. */
         addi s1, s1, 1024
 
     /* Pack pk */
@@ -407,7 +407,7 @@ crypto_sign_keypair:
     bn.sid t0, 0(a0++)
 
     /* Load pointer to t1 */
-    li  a1, STACK_T1
+    li  a1, STACK_T
     add a1, fp, a1
 
     /* Pack t1 */

--- a/sw/otbn/crypto/mldsa/mldsa_keypair.s
+++ b/sw/otbn/crypto/mldsa/mldsa_keypair.s
@@ -181,27 +181,22 @@ crypto_sign_keypair:
     #define STACK_SK_ADDR -168
     #define STACK_TR      -256
     #define STACK_TMP    -1280 /* Prev - 1024 */
+    #define STACK_S1     -2304 /* Prev - 1024 */
 #if DILITHIUM_MODE == 2
-    #define STACK_S1  -5376 /* Prev - L*1024 */
-    #define STACK_S2  -9472 /* Prev - K*1024 */
-    #define STACK_T1  -13568 /* Prev - K*1024 */
-    #define STACK_T0  -17664 /* Prev - K*1024 */
-    #define STACK_S1_HAT  -21760 /* Prev - L*1024 */
-    #define INIT_SP -21760
+    #define STACK_S2  -6400 /* Prev - K*1024 */
+    #define STACK_T1  -10496 /* Prev - K*1024 */
+    #define STACK_T0  -14592 /* Prev - K*1024 */
+    #define INIT_SP -14592
 #elif DILITHIUM_MODE == 3
-    #define STACK_S1  -6400 /* Prev - L*1024 */
-    #define STACK_S2  -12544 /* Prev - K*1024 */
-    #define STACK_T1  -18688 /* Prev - K*1024 */
-    #define STACK_T0  -24832 /* Prev - K*1024 */
-    #define STACK_S1_HAT  -29952 /* Prev - L*1024 */
-    #define INIT_SP -29952
+    #define STACK_S2  -8448 /* Prev - K*1024 */
+    #define STACK_T1  -14592 /* Prev - K*1024 */
+    #define STACK_T0  -20736 /* Prev - K*1024 */
+    #define INIT_SP -20736
 #elif DILITHIUM_MODE == 5
-    #define STACK_S1  -8448 /* Prev - L*1024 */
-    #define STACK_S2  -16640 /* Prev - K*1024 */
-    #define STACK_T1  -24832 /* Prev - K*1024 */
-    #define STACK_T0  -33024 /* Prev - K*1024 */
-    #define STACK_S1_HAT  -40192 /* Prev - L*1024 */
-    #define INIT_SP -40192
+    #define STACK_S2  -10496 /* Prev - K*1024 */
+    #define STACK_T1  -18688 /* Prev - K*1024 */
+    #define STACK_T0  -26880 /* Prev - K*1024 */
+    #define INIT_SP -26880
 #endif
     /* Initialize the frame pointer */
     addi fp, sp, 0
@@ -259,20 +254,6 @@ crypto_sign_keypair:
 
     /* Finish the SHAKE-256 operation. */
 
-    /* Sample s1 */
-
-    li a2, 0 /* initialize the nonce */
-
-    /* Load output pointer */
-    li  a1, STACK_S1
-    add a1, fp, a1
-
-    LOOPI L, 3
-        /* Load pointer to input */
-        addi a0, fp, STACK_RHOPRIME
-        jal  x1, poly_uniform_eta
-        addi a2, a2, 1
-
     /* Sample s2 */
 
     /* initialize the nonce */
@@ -288,35 +269,12 @@ crypto_sign_keypair:
         jal  x1, poly_uniform_eta /* Implicit increment of output pointer */
         addi a2, a2, 1
 
-    /* NTT(s1) */
-    /* Load pointer to input polynomial */
-    li  a0, STACK_S1
-    add a0, fp, a0
-    /* Load pointer to twiddle factors */
-    la  a1, twiddles_fwd
-    /* Load pointer to output polynomial */
-    li  a2, STACK_S1_HAT
-    add a2, fp, a2
-
-    .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-        push \reg
-    .endr
-
-    bn.wsrr   w16, 0x0 /* w16 = R | Q */
-    bn.shv.8S w0, w16 << 1 /* w0 = 2*R | 2*Q */
-    bn.wsrw   0x0, w0 /* MOD = 2*R | 2*Q */
-    LOOPI L, 2
-        jal x1, ntt
-        addi a1, a1, -1024
-
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-        pop \reg
-    .endr
-
-    /* After NTT, w16 is still R | Q and MOD is still 2*R | 2*Q */
+    bn.wsrr   w16, mod /* w16 = R | Q */
+    bn.shv.8S w22, w16 << 1 /* w22 = 2*R | 2*Q */
+    bn.wsrw   mod, w22 /* MOD = 2*R | 2*Q */
 
     /* Load source pointers for matrix-vector multiplication. */
-    li  s0, STACK_S1_HAT
+    li  s0, STACK_S1
     add s0, fp, s0
     li  s1, STACK_TMP
     add s1, fp, s1
@@ -334,35 +292,75 @@ crypto_sign_keypair:
         nop
 
     /* Load offset for resetting vector pointer. */
-    li s3, POLYVECL_BYTES
+    li s3, POLYVECK_BYTES
 
     /* Initialize the nonce for matrix expansion. This value should be
          byte(i) || byte(j)
        for entry A[i][j]. */
     li s4, 0
 
-     /* Compute A * s1, computing elements of A on the fly. */
-    loopi K, 15
-        loopi L, 10
+    /* Load pointer to twiddle factors for NTT */
+    la  s5, twiddles_fwd
+
+    /* Initialize the nonce for sampling s1. */
+    li   s6, 0
+
+    /* Load the destination for packed s1 within the secret key. */
+    li   t1, STACK_SK_ADDR
+    add  t1, fp, t1
+    lw   s7, 0(t1)
+    addi s7, s7, 128
+
+    /* Compute A * s1, computing elements of A on the fly.
+
+       We compute column-wise so that we generate elements of s1 only once; in
+       pseudocode, this computation does:
+
+         for j in 0..l-1:
+           s1j = ntt(s1[j])
+           for i in 0..k-1:
+             out[i] += A[i][j] * s1j
+    */
+    loopi L, 29
+        bn.wsrw   mod, w16 /* MOD = R | Q */
+        /* Sample the next polynomial from s1. */
+        addi a0, fp, STACK_RHOPRIME
+        addi a1, s0, 0
+        addi a2, s6, 0
+        jal  x1, poly_uniform_eta
+        addi s6, s6, 1
+        /* Pack the s1 polynomial into the secret key. */
+        addi a0, s7, 0
+        addi a1, s0, 0
+        jal x1, polyeta_pack
+        addi s7, a0, 0
+        bn.wsrw   mod, w22 /* MOD = 2*R | 2*Q */
+        /* Compute ntt(s1[j]). */
+        addi a0, s0, 0
+        addi a1, s5, 0
+        addi a2, s0, 0
+        jal  x1, ntt
+        loopi K, 10
             /* Compute A[i][j]. */
             addi a0, fp, STACK_RHO
             addi a1, s1, 0
             addi a2, s4, 0
             jal  x1, poly_uniform
-            /* Increment the matrix nonce. */
-            addi s4, s4, 1
+            /* Increment the row in the matrix nonce (upper byte). */
+            addi s4, s4, 256
             /* Compute A[i][j] * s1[j] and add it to the output at index i. */
             addi a0, s0, 0
             addi a1, s1, 0
             addi a2, s2, 0
             jal  x1, poly_pointwise_acc
-            addi s0, s0, 1024
-        /* Reset input vector pointer */
-        sub  s0, s0, s3
-        addi s2, s2, 1024
-        /* Adjust the matrix nonce to reset the column and increment the row. */
-        addi s4, s4, 256
-        addi s4, s4, -L
+            /* Increment the output vector pointer. */
+            addi s2, s2, 1024
+        /* Reset output vector pointer. */
+        sub  s2, s2, s3
+        /* Increment the column index in the nonce by one. */
+        addi s4, s4, 1
+        /* Reset the row index in the nonce to zero. */
+        andi s4, s4, 255
 
     /* After poly_pointwise, w16 is still R | Q and MOD is still 2*R | 2*Q */
     /* Inverse NTT on t1 */
@@ -509,14 +507,8 @@ crypto_sign_keypair:
     bn.lid t0, 0(t1++)
     bn.sid t0, 0(a0++)
 
-    /* Load pointer to s1 */
-    li  a1, STACK_S1
-    add a1, fp, a1
-
-    /* Store s1 */
-    LOOPI L, 2
-        jal x1, polyeta_pack
-        nop
+    /* Skip s1, since it was already packed earlier. */
+    addi a0, s7, 0
 
     /* Load pointer to s2 */
     li  a1, STACK_S2

--- a/sw/otbn/crypto/mldsa/mldsa_keypair.s
+++ b/sw/otbn/crypto/mldsa/mldsa_keypair.s
@@ -173,16 +173,13 @@ crypto_sign_keypair:
     #define STACK_S1     -2304 /* Prev - 1024 */
 #if DILITHIUM_MODE == 2
     #define STACK_T1  -6400 /* Prev - K*1024 */
-    #define STACK_T0  -10496 /* Prev - K*1024 */
-    #define INIT_SP -10496
+    #define INIT_SP -6400
 #elif DILITHIUM_MODE == 3
     #define STACK_T1  -8448 /* Prev - K*1024 */
-    #define STACK_T0  -14592 /* Prev - K*1024 */
-    #define INIT_SP -14592
+    #define INIT_SP -8448
 #elif DILITHIUM_MODE == 5
     #define STACK_T1  -10496 /* Prev - K*1024 */
-    #define STACK_T0  -18688 /* Prev - K*1024 */
-    #define INIT_SP -18688
+    #define INIT_SP -10496
 #endif
     /* Initialize the frame pointer */
     addi fp, sp, 0
@@ -375,21 +372,23 @@ crypto_sign_keypair:
         /* Increment polyvec pointer. */
         addi s1, s1, 1024
 
-    /* power2round */
+    /* Reset t1 pointer for power2round loop. */
+    li  s1, STACK_T1
+    add s1, fp, s1
 
-    /* Load source pointer */
-    li  a0, STACK_T1
-    add a0, fp, a0
-
-    /* Load destination pointer */
-    li  a1, STACK_T0
-    add a1, fp, a1
-    li  a2, STACK_T1
-    add a2, fp, a2
-
-    LOOPI K, 2
-        jal x1, poly_power2round
-        nop
+    LOOPI K, 9
+        /* Split t polynomial into t0 (tmp buffer) and t1 (t1 buffer). */
+        addi a0, s1, 0
+        addi a1, s0, 0
+        addi a2, s1, 0
+        jal  x1, poly_power2round
+        /* Pack the t0 polynomial into secret key. */
+        addi a0, s7, 0
+        addi a1, s0, 0
+        jal  x1, polyt0_pack
+        addi s7, a0, 0
+        /* Increment polyvec pointer. */
+        addi s1, s1, 1024
 
     /* Pack pk */
 
@@ -482,18 +481,6 @@ crypto_sign_keypair:
     bn.sid t0, 0(a0++)
     bn.lid t0, 0(t1++)
     bn.sid t0, 0(a0++)
-
-    /* Skip s1 and s2, since they were already packed earlier. */
-    addi a0, s7, 0
-
-    /* Load pointer to t0 */
-    li  a1, STACK_T0
-    add a1, fp, a1
-
-    /* Store packed(t0) */
-    LOOPI K, 2
-        jal x1, polyt0_pack
-        nop
 
     /* Free space on the stack */
     addi sp, fp, 0

--- a/sw/otbn/crypto/mldsa/mldsa_keypair.s
+++ b/sw/otbn/crypto/mldsa/mldsa_keypair.s
@@ -172,20 +172,17 @@ crypto_sign_keypair:
     #define STACK_TMP    -1280 /* Prev - 1024 */
     #define STACK_S1     -2304 /* Prev - 1024 */
 #if DILITHIUM_MODE == 2
-    #define STACK_S2  -6400 /* Prev - K*1024 */
-    #define STACK_T1  -10496 /* Prev - K*1024 */
+    #define STACK_T1  -6400 /* Prev - K*1024 */
+    #define STACK_T0  -10496 /* Prev - K*1024 */
+    #define INIT_SP -10496
+#elif DILITHIUM_MODE == 3
+    #define STACK_T1  -8448 /* Prev - K*1024 */
     #define STACK_T0  -14592 /* Prev - K*1024 */
     #define INIT_SP -14592
-#elif DILITHIUM_MODE == 3
-    #define STACK_S2  -8448 /* Prev - K*1024 */
-    #define STACK_T1  -14592 /* Prev - K*1024 */
-    #define STACK_T0  -20736 /* Prev - K*1024 */
-    #define INIT_SP -20736
 #elif DILITHIUM_MODE == 5
-    #define STACK_S2  -10496 /* Prev - K*1024 */
-    #define STACK_T1  -18688 /* Prev - K*1024 */
-    #define STACK_T0  -26880 /* Prev - K*1024 */
-    #define INIT_SP -26880
+    #define STACK_T1  -10496 /* Prev - K*1024 */
+    #define STACK_T0  -18688 /* Prev - K*1024 */
+    #define INIT_SP -18688
 #endif
     /* Initialize the frame pointer */
     addi fp, sp, 0
@@ -242,21 +239,6 @@ crypto_sign_keypair:
         bn.sid  t0, 0(t1++) /* Store into buffer */
 
     /* Finish the SHAKE-256 operation. */
-
-    /* Sample s2 */
-
-    /* initialize the nonce */
-    li a2, L
-
-    /* Load output pointer */
-    li  a1, STACK_S2
-    add a1, fp, a1
-
-    LOOPI K, 3
-        /* Load pointer to input */
-        addi a0, fp, STACK_RHOPRIME
-        jal  x1, poly_uniform_eta /* Implicit increment of output pointer */
-        addi a2, a2, 1
 
     bn.wsrr   w16, mod /* w16 = R | Q */
     bn.shv.8S w22, w16 << 1 /* w22 = 2*R | 2*Q */
@@ -363,21 +345,35 @@ crypto_sign_keypair:
         addi a0, a0, 1024 /* Go to next input polynomial */
     bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
 
-    /* t1+s2 */
+    /* Load pointers for loop. */
+    li  s0, STACK_TMP
+    add s0, fp, s0
+    li  s1, STACK_T1
+    add s1, fp, s1
 
-    /* Load source pointers */
-    li  a0, STACK_S2
-    add a0, fp, a0
-    li  a1, STACK_T1
-    add a1, fp, a1
+    /* Initialize the nonce for sampling s2. */
+    li s6, L
 
-    /* Load destination pointer */
-    li  a2, STACK_T1
-    add a2, fp, a2
-
-    LOOPI K, 2
-        jal x1, poly_add
-        nop
+    /* This loop samples s2 and adds it to A*s1 (currently in the t1 buffer). */
+    LOOPI K, 14
+        /* Sample the next polynomial from s2 and store in temp buffer. */
+        addi a0, fp, STACK_RHOPRIME
+        addi a1, s0, 0
+        addi a2, s6, 0
+        jal  x1, poly_uniform_eta
+        addi s6, s6, 1
+        /* Pack the s2 polynomial into the secret key. */
+        addi a0, s7, 0
+        addi a1, s0, 0
+        jal  x1, polyeta_pack
+        addi s7, a0, 0
+        /* t[i] += s2 */
+        addi a0, s0, 0
+        addi a1, s1, 0
+        addi a2, s1, 0
+        jal  x1, poly_add
+        /* Increment polyvec pointer. */
+        addi s1, s1, 1024
 
     /* power2round */
 
@@ -487,17 +483,8 @@ crypto_sign_keypair:
     bn.lid t0, 0(t1++)
     bn.sid t0, 0(a0++)
 
-    /* Skip s1, since it was already packed earlier. */
+    /* Skip s1 and s2, since they were already packed earlier. */
     addi a0, s7, 0
-
-    /* Load pointer to s2 */
-    li  a1, STACK_S2
-    add a1, fp, a1
-
-    /* Store packed(s2) */
-    LOOPI K, 2
-        jal x1, polyeta_pack
-        nop
 
     /* Load pointer to t0 */
     li  a1, STACK_T0

--- a/sw/otbn/crypto/mldsa/mldsa_keypair.s
+++ b/sw/otbn/crypto/mldsa/mldsa_keypair.s
@@ -174,12 +174,15 @@ crypto_sign_keypair:
 #if DILITHIUM_MODE == 2
     #define STACK_T -6400 /* Prev - K*1024 */
     #define INIT_SP -6400
+    #define STACK_SIZE 6528 /* Expected stack size for reference (unused). */
 #elif DILITHIUM_MODE == 3
     #define STACK_T -8448 /* Prev - K*1024 */
     #define INIT_SP -8448
+    #define STACK_SIZE 8576 /* Expected stack size for reference (unused). */
 #elif DILITHIUM_MODE == 5
     #define STACK_T -10496 /* Prev - K*1024 */
     #define INIT_SP -10496
+    #define STACK_SIZE 10624 /* Expected stack size for reference (unused). */
 #endif
     /* Initialize the frame pointer */
     addi fp, sp, 0

--- a/sw/otbn/crypto/mldsa/mldsa_keypair.s
+++ b/sw/otbn/crypto/mldsa/mldsa_keypair.s
@@ -147,17 +147,6 @@
 /* Config to start a SHA3_512 operation. */
 #define SHA3_512_CFG 0x10
 
-/* Macros */
-.macro push reg
-    addi sp, sp, -4      /* Decrement stack pointer by 4 bytes */
-    sw \reg, 0(sp)      /* Store register value at the top of the stack */
-.endm
-
-.macro pop reg
-    lw \reg, 0(sp)      /* Load value from the top of the stack into register */
-    addi sp, sp, 4     /* Increment stack pointer by 4 bytes */
-.endm
-
 /**
  * Dilithium Key Pair generation
  *
@@ -368,20 +357,11 @@ crypto_sign_keypair:
     add a0, fp, a0
     la  a1, twiddles_inv
 
-    .irp reg,t0,t1,t2,t3,t4,t5,t6,a0,a1,a2,a3,a4,a5,a6,a7
-        push \reg
-    .endr
-
     LOOPI K, 3
         jal  x1, intt
         addi a1, a1, -960 /* Reset the twiddle pointer */
         addi a0, a0, 1024 /* Go to next input polynomial */
     bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
-
-    /* Restore caller-saved registers */
-    .irp reg,a7,a6,a5,a4,a3,a2,a1,a0,t6,t5,t4,t3,t2,t1,t0
-        pop \reg
-    .endr
 
     /* t1+s2 */
 

--- a/sw/otbn/crypto/mldsa/poly.s
+++ b/sw/otbn/crypto/mldsa/poly.s
@@ -658,27 +658,9 @@ _loop_inner_skip_load_poly_challenge:
  */
 .global poly_uniform
 poly_uniform:
-    /* 32 byte align the sp */
-    andi a5, sp, 31
-    beq  a5, zero, _aligned
-    sub  sp, sp, a5
-_aligned:
-    /* save fp to stack, use 32 bytes to keep it 32-byte aligned */
-    addi sp, sp, -32
-    sw   fp, 0(sp)
-
-    addi fp, sp, 0
-
-    /* Adjust sp to accomodate local variables */
-    addi sp, sp, -64
-
-    /* Space for tmp buffer to hold a WDR */
-    #define STACK_WDR2GPR -32
-    /* Space for the nonce */
-    #define STACK_NONCE -64
-
-    /* Store nonce to memory */
-    sw a2, STACK_NONCE(fp)
+    /* Save nonce to memory (use poly tmp buffer). */
+    la t0, poly_wdr2gpr
+    sw a2, 0(t0)
 
     /* Load Q to GPR */
     la t0, modulus
@@ -695,7 +677,7 @@ _aligned:
     li   a1, 32                  /* set message length */
     jal  x1, keccak_send_message /* a0 already contains the input buffer */
     addi a1, zero, 2             /* set message length */
-    addi a0, fp, STACK_NONCE     /* Set a0 to point to the nonce in memory */
+    la   a0, poly_wdr2gpr        /* Set a0 to point to the nonce in memory */
     jal  x1, keccak_send_message
 
     addi a1, a4, 0 /* move output pointer back to a1 */
@@ -843,14 +825,6 @@ _skip_store4:
 _end_rej_sample_loop:
     /* Finish the SHAKE-256 operation. */
 
-    /* sp <- fp */
-    addi sp, fp, 0
-    /* Pop ebp */
-    lw fp, 0(sp)
-    addi sp, sp, 32
-    /* Correct alignment offset (unalign) */
-    add sp, sp, a5
-
     ret
 
 _poly_uniform_inner_loop:
@@ -900,28 +874,9 @@ _skip_store1:
  */
 .global poly_uniform_eta
 poly_uniform_eta:
-/* 32 byte align the sp */
-    andi a5, sp, 31
-    beq  a5, zero, _aligned_poly_uniform_eta
-    sub  sp, sp, a5
-_aligned_poly_uniform_eta:
-    /* save fp to stack, use 32 bytes to keep it 32-byte aligned */
-    addi sp, sp, -32
-    sw   fp, 0(sp)
-
-    addi fp, sp, 0
-
-    /* Adjust sp to accomodate local variables */
-    addi sp, sp, -64
-
-    /* Space for tmp buffer to hold a WDR */
-    #define STACK_WDR2GPR -32
-
-    /* Space for the nonce */
-    #define STACK_NONCE -64
-
-    /* Store nonce to memory */
-    sw a2, STACK_NONCE(fp)
+    /* Save nonce to memory (use poly tmp buffer). */
+    la t0, poly_wdr2gpr
+    sw a2, 0(t0)
 
     /* Load a3 <= Q */
     la t0, modulus
@@ -940,7 +895,7 @@ _aligned_poly_uniform_eta:
     addi a0, a0, 0
     jal  x1, keccak_send_message /* a0 already contains the input buffer */
     addi a1, zero, 2             /* set nonce length */
-    addi a0, fp, STACK_NONCE     /* After rho, absorb nonce */
+    la   a0, poly_wdr2gpr        /* After rho, absorb nonce */
     jal  x1, keccak_send_message
     addi a1, a4, 0 /* move output pointer back to a1 */
 
@@ -1020,14 +975,6 @@ _rej_eta_sample_loop_continue:
 
 _end_rej_eta_sample_loop:
     /* Finish the SHAKE-256 operation. */
-
-    /* sp <- fp */
-    addi sp, fp, 0
-    /* Pop ebp */
-    lw   fp, 0(sp)
-    addi sp, sp, 32
-    /* Correct alignment offset (unalign) */
-    add  sp, sp, a5
 
     ret
 

--- a/sw/otbn/crypto/tests/mldsa/mldsa_keypair_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_keypair_test.s
@@ -13,11 +13,11 @@
 
 .section .text.start
 #if DILITHIUM_MODE == 2
-    #define STACK_SIZE 21888
+    #define STACK_SIZE 14720
 #elif DILITHIUM_MODE == 3
-    #define STACK_SIZE 30080
+    #define STACK_SIZE 20864
 #elif DILITHIUM_MODE == 5
-    #define STACK_SIZE 40320
+    #define STACK_SIZE 27008
 #endif
 
 #define SEEDBYTES 32

--- a/sw/otbn/crypto/tests/mldsa/mldsa_keypair_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_keypair_test.s
@@ -13,11 +13,11 @@
 
 .section .text.start
 #if DILITHIUM_MODE == 2
-    #define STACK_SIZE 14720
+    #define STACK_SIZE 10624
 #elif DILITHIUM_MODE == 3
-    #define STACK_SIZE 20864
+    #define STACK_SIZE 14720
 #elif DILITHIUM_MODE == 5
-    #define STACK_SIZE 27008
+    #define STACK_SIZE 18816
 #endif
 
 #define SEEDBYTES 32

--- a/sw/otbn/crypto/tests/mldsa/mldsa_keypair_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_keypair_test.s
@@ -12,7 +12,13 @@
 */
 
 .section .text.start
-#define STACK_SIZE 112000
+#if DILITHIUM_MODE == 2
+    #define STACK_SIZE 21888
+#elif DILITHIUM_MODE == 3
+    #define STACK_SIZE 30080
+#elif DILITHIUM_MODE == 5
+    #define STACK_SIZE 40320
+#endif
 
 #define SEEDBYTES 32
 #define CRHBYTES 64

--- a/sw/otbn/crypto/tests/mldsa/mldsa_keypair_test.s
+++ b/sw/otbn/crypto/tests/mldsa/mldsa_keypair_test.s
@@ -13,11 +13,11 @@
 
 .section .text.start
 #if DILITHIUM_MODE == 2
-    #define STACK_SIZE 10624
+    #define STACK_SIZE 6528
 #elif DILITHIUM_MODE == 3
-    #define STACK_SIZE 14720
+    #define STACK_SIZE 8576
 #elif DILITHIUM_MODE == 5
-    #define STACK_SIZE 18816
+    #define STACK_SIZE 10624
 #endif
 
 #define SEEDBYTES 32


### PR DESCRIPTION
After this change, ML-DSA-87 requires only 11kB of stack, and 21kB of memory overall (including constants and I/O buffers). According to my back-of-napkin calculations, this should be enough to enable first-order masking on ML-DSA-87 within 32kB of DMEM:

- Masks for (packed) `key`, `s0` and `s1` in secret key: 1472 bytes
- Mask for temporary polynomial buffer: 1024 bytes
- Mask for `t` polyvec: 8192 bytes

Total overhead per additional masking order: 10688 bytes

As with `verify`, the performance impact is pretty small because data structures are only processed once. Spot-checks from the simulator tests indicate a small slowdown:
```
ML-DSA-44: 140325 -> 140627 (+0.22%)
ML-DSA-65: 247816 -> 248298 (+0.19%)
ML-DSA-87: 388340 -> 388883 (+0.14%)
```
