### PR TITLE
[otbn, otbnsim] Updated illegal insn and ispr generators based on PQC parameter value

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/csr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/csr.py
@@ -72,16 +72,6 @@ class CSRFile:
             # KMAC_STATUS register
             return wsrs.KMAC_STATUS.read_unsigned()
 
-        if 0x7e3 <= idx <= 0x7ea:
-            # KMAC_DIGEST_SHARE0
-            digest_n = idx - 0x7e3
-            return self._get_field(digest_n, 32, wsrs.KMAC_DIGEST_SHARE0.read_unsigned())
-
-        if 0x7eb <= idx <= 0x7f2:
-            # KMAC_DIGEST_SHARE1
-            digest_n = idx - 0x7eb
-            return self._get_field(digest_n, 32, wsrs.KMAC_DIGEST_SHARE1.read_unsigned())
-
         if idx == 0x7f3:
             # KMAC_PARTIAL_WRITE
             return 0

--- a/hw/ip/otbn/dv/otbnsim/sim/csr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/csr.py
@@ -12,7 +12,8 @@ from .wsr import WSRFile
 
 class CSRFile:
     '''A model of the CSR file'''
-    def __init__(self) -> None:
+    def __init__(self, pqc: bool) -> None:
+        self.EN_PQC = pqc
         self.flags = FlagGroups()
 
         self._known_indices = set()
@@ -22,11 +23,12 @@ class CSRFile:
         for idx in range(0x7d0, 0x7d8):
             self._known_indices.add(idx)  # MODi
         self._known_indices.add(0x7d8)  # RND_PREFETCH
-        self._known_indices.add(0x7d9)  # KMAC_CFG
-        self._known_indices.add(0x7e2)  # KMAC_STATUS
-        self._known_indices.add(0x7f3)  # KMAC_PARTIAL_WRITE
         self._known_indices.add(0xfc0)  # RND
         self._known_indices.add(0xfc1)  # URND
+        if self.EN_PQC:
+            self._known_indices.add(0x7d9)  # KMAC_CFG
+            self._known_indices.add(0x7e2)  # KMAC_STATUS
+            self._known_indices.add(0x7f3)  # KMAC_PARTIAL_WRITE
 
     @staticmethod
     def _get_field(field_idx: int, field_size: int, val: int) -> int:
@@ -64,15 +66,15 @@ class CSRFile:
             # RND_PREFETCH register
             return 0
 
-        if idx == 0x7d9:
+        if idx == 0x7d9 and self.EN_PQC:
             # KMAC_CFG register
             return 0
 
-        if idx == 0x7e2:
+        if idx == 0x7e2 and self.EN_PQC:
             # KMAC_STATUS register
             return wsrs.KMAC_STATUS.read_unsigned()
 
-        if idx == 0x7f3:
+        if idx == 0x7f3 and self.EN_PQC:
             # KMAC_PARTIAL_WRITE
             return 0
 

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -781,6 +781,9 @@ class BNADDV(OTBNInsn):
         self.type = op_vals['type']
 
     def execute(self, state: OTBNState) -> None:
+        if not state.wsrs.EN_PQC:
+            state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
+
         a = state.wdrs.get_reg(self.wrs1).read_unsigned()
         b = state.wdrs.get_reg(self.wrs2).read_unsigned()
         mod_val = state.wsrs.MOD.read_unsigned()
@@ -815,6 +818,9 @@ class BNMULV(OTBNInsn):
         self.type = op_vals['type']
 
     def execute(self, state: OTBNState) -> None:
+        if not state.wsrs.EN_PQC:
+            state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
+
         wrs1 = state.wdrs.get_reg(self.wrs1).read_unsigned()
         wrs2 = state.wdrs.get_reg(self.wrs2).read_unsigned()
 
@@ -923,6 +929,9 @@ class BNMULVL(OTBNInsn):
         self.lane_index = op_vals['lane_index']
 
     def execute(self, state: OTBNState) -> None:
+        if not state.wsrs.EN_PQC:
+            state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
+
         # Extract fields in the encoding:
         #    data_type:    0 = .16H, 1 = .8S
         #    sel:       0 = .even, 1 = .odd
@@ -1277,6 +1286,9 @@ class BNSUBV(OTBNInsn):
         self.type = op_vals['type']
 
     def execute(self, state: OTBNState) -> None:
+        if not state.wsrs.EN_PQC:
+            state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
+
         a = state.wdrs.get_reg(self.wrs1).read_unsigned()
         b = state.wdrs.get_reg(self.wrs2).read_unsigned()
         mod_val = state.wsrs.MOD.read_unsigned()
@@ -1432,6 +1444,9 @@ class BNSHV(OTBNInsn):
         self.shift_arith = op_vals['shift_arith']
 
     def execute(self, state: OTBNState) -> None:
+        if not state.wsrs.EN_PQC:
+            state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
+
         a = state.wdrs.get_reg(self.wrs1).read_unsigned()
 
         size = 32 if self.type == 0 else 16
@@ -1809,6 +1824,9 @@ class BNTRN(OTBNInsn):
         self.type = op_vals['type']
 
     def execute(self, state: OTBNState) -> None:
+        if not state.wsrs.EN_PQC:
+            state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
+
         a = state.wdrs.get_reg(self.wrs1).read_unsigned()
         b = state.wdrs.get_reg(self.wrs2).read_unsigned()
 

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -781,7 +781,7 @@ class BNADDV(OTBNInsn):
         self.type = op_vals['type']
 
     def execute(self, state: OTBNState) -> None:
-        if not state.wsrs.EN_PQC:
+        if not state.EN_PQC:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
 
         a = state.wdrs.get_reg(self.wrs1).read_unsigned()
@@ -818,7 +818,7 @@ class BNMULV(OTBNInsn):
         self.type = op_vals['type']
 
     def execute(self, state: OTBNState) -> None:
-        if not state.wsrs.EN_PQC:
+        if not state.EN_PQC:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
 
         wrs1 = state.wdrs.get_reg(self.wrs1).read_unsigned()
@@ -929,7 +929,7 @@ class BNMULVL(OTBNInsn):
         self.lane_index = op_vals['lane_index']
 
     def execute(self, state: OTBNState) -> None:
-        if not state.wsrs.EN_PQC:
+        if not state.EN_PQC:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
 
         # Extract fields in the encoding:
@@ -1286,7 +1286,7 @@ class BNSUBV(OTBNInsn):
         self.type = op_vals['type']
 
     def execute(self, state: OTBNState) -> None:
-        if not state.wsrs.EN_PQC:
+        if not state.EN_PQC:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
 
         a = state.wdrs.get_reg(self.wrs1).read_unsigned()
@@ -1444,7 +1444,7 @@ class BNSHV(OTBNInsn):
         self.shift_arith = op_vals['shift_arith']
 
     def execute(self, state: OTBNState) -> None:
-        if not state.wsrs.EN_PQC:
+        if not state.EN_PQC:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
 
         a = state.wdrs.get_reg(self.wrs1).read_unsigned()
@@ -1829,7 +1829,7 @@ class BNTRN(OTBNInsn):
         self.type = op_vals['type']
 
     def execute(self, state: OTBNState) -> None:
-        if not state.wsrs.EN_PQC:
+        if not state.EN_PQC:
             state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
 
         a = state.wdrs.get_reg(self.wrs1).read_unsigned()

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -1797,6 +1797,11 @@ class BNWSRW(OTBNInsn):
     def execute(self, state: OTBNState) -> None:
         if DEBUG_KMAC:
             eprint(f"\tRun BNWSRW Address {self.wsr}")
+        if not state.wsrs.check_idx(self.wsr):
+            # Invalid WSR index. Stop with an illegal instruction error.
+            state.stop_at_end_of_cycle(ErrBits.ILLEGAL_INSN)
+            return None
+
         dest_wsrs = state.wsrs._by_idx[self.wsr]
         if self.wsr == 0x9:
             # A write to KMAC_MSG might stall, if the register has not yet pushed

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -1,9 +1,9 @@
 # Copyright lowRISC contributors (OpenTitan project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
 # Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192).
 # Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors.
-
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
 
 from typing import Dict, Iterator, List, Optional, Tuple
 
@@ -26,8 +26,9 @@ StepRes = Tuple[Optional[OTBNInsn], List[Trace]]
 
 
 class OTBNSim:
-    def __init__(self) -> None:
-        self.state = OTBNState()
+    def __init__(self, pqc: bool) -> None:
+        self.EN_PQC = pqc
+        self.state = OTBNState(self.EN_PQC)
         self.program: List[OTBNInsn] = []
         self.loop_warps: LoopWarps = {}
         self.stats: Optional[ExecutionStats] = None

--- a/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -22,6 +23,9 @@ _TEST_URND_DATA = [
 
 
 class StandaloneSim(OTBNSim):
+    def __init__(self, pqc: bool) -> None:
+        super().__init__(pqc=pqc)
+
     def run(self, verbose: bool, dump_file: Optional[TextIO]) -> int:
         '''Run until ECALL.
 

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -77,14 +78,15 @@ class InitSecWipeState(IntEnum):
 
 
 class OTBNState:
-    def __init__(self) -> None:
+    def __init__(self, pqc: bool) -> None:
+        self.EN_PQC = pqc
         self.gprs = GPRs()
         self.wdrs = RegFile('w', 256, 32)
 
         self.ext_regs = OTBNExtRegs()
         self.kmac = KmacBlock()
-        self.wsrs = WSRFile(self.ext_regs, self.kmac)
-        self.csrs = CSRFile()
+        self.wsrs = WSRFile(self.ext_regs, self.kmac, self.EN_PQC)
+        self.csrs = CSRFile(self.EN_PQC)
 
         self.pc = 0
         self._pc_next_override: Optional[int] = None
@@ -366,7 +368,7 @@ class OTBNState:
         # Reset CSRs, WSRs, loop stack and call stack. WSRs have special
         # treatment because some of them have values that persist across
         # operations.
-        self.csrs = CSRFile()
+        self.csrs = CSRFile(self.EN_PQC)
         self.wsrs.on_start()
         self.loop_stack = LoopStack()
         self.gprs.empty_call_stack()

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -643,11 +643,15 @@ class WSRFile:
             5: self.KeyS0H,
             6: self.KeyS1L,
             7: self.KeyS1H,
-            8: self.KMAC_CFG,
-            9: self.KMAC_MSG,
-            10: self.KMAC_DIGEST,
-            11: self.ACCH,
         }
+
+        if self.EN_PQC:
+            self._by_idx.update({
+                8: self.KMAC_CFG,
+                9: self.KMAC_MSG,
+                10: self.KMAC_DIGEST,
+                11: self.ACCH,
+            })
 
     def on_start(self) -> None:
         '''Called at the start of an operation

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -11,7 +11,6 @@
 
 
 import sys
-import os
 from typing import List, Optional, Sequence, Tuple
 from .trace import Trace
 from .ext_regs import OTBNExtRegs
@@ -613,8 +612,8 @@ class KmacDigestWSR(WSR):
 
 class WSRFile:
     '''A model of the WSR file'''
-    def __init__(self, ext_regs: OTBNExtRegs, kmac: KmacBlock) -> None:
-        self.EN_PQC = int(os.environ.get("PQC_EN", '0'))
+    def __init__(self, ext_regs: OTBNExtRegs, kmac: KmacBlock, pqc: bool) -> None:
+        self.EN_PQC = pqc
         self.KeyS0 = SideloadKey('KeyS0')
         self.KeyS1 = SideloadKey('KeyS1')
         self.Kmac = kmac
@@ -634,6 +633,7 @@ class WSRFile:
         self.KMAC_CFG = KmacCfgWSR('KMAC_CFG', self.Kmac, self.KMAC_PARTIAL_WRITE)
         self.KMAC_MSG = KmacMsgWSR('KMAC_MSG', self.Kmac, self.KMAC_PARTIAL_WRITE)
 
+        # These are the common index regardless of PQC enable or not
         self._by_idx = {
             0: self.MOD,
             1: self.RND,

--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 # Copyright lowRISC contributors (OpenTitan project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
 # Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192).
 # Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors.
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
 
 
 import argparse
@@ -48,6 +49,11 @@ def main() -> int:
         help=("after execution, write execution statistics to this file. "
               "Use '-' to write to STDOUT.")
     )
+    parser.add_argument(
+        '--pqc',
+        type=bool,
+        help=("set otbnsim to PQC feature mode for ML-KEM and ML-DSA.")
+    )
 
     args = parser.parse_args()
 
@@ -58,7 +64,7 @@ def main() -> int:
     if coverage_dat:
         collect_stats = True
 
-    sim = StandaloneSim()
+    sim = StandaloneSim(args.pqc)
     exp_end_addr = load_elf(sim, args.elf, args.dump_rtl_sim)
 
     testcase = None

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -74,6 +75,7 @@ prefixed with "0x" if they are hexadecimal.
 
 import binascii
 import sys
+import os
 from typing import List, Optional
 
 from sim.decode import decode_file
@@ -292,7 +294,7 @@ def on_print_call_stack(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
 
 def on_reset(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     check_arg_count('reset', 0, args)
-    return OTBNSim()
+    return OTBNSim(get_pqc_mode())
 
 
 def on_edn_rnd_step(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
@@ -452,8 +454,12 @@ def on_input(sim: OTBNSim, line: str) -> Optional[OTBNSim]:
     return ret
 
 
+def get_pqc_mode() -> int:
+    return int(os.environ.get("PQC_EN", '0'))
+
+
 def main() -> int:
-    sim = OTBNSim()
+    sim = OTBNSim(get_pqc_mode())
     try:
         for line in sys.stdin:
             ret = on_input(sim, line)

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_insn.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_insn.py
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_insn.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_insn.py
@@ -8,7 +8,7 @@ from typing import Optional
 from shared.insn_yaml import InsnsFile
 
 from ..config import Config
-from ..program import DummyProgInsn, Program
+from ..program import DummyProgInsn, ProgInsn, Program
 from ..model import Model
 from ..snippet import ProgSnippet
 from ..snippet_gen import GenCont, GenRet, SnippetGen
@@ -26,6 +26,16 @@ class BadInsn(SnippetGen):
         # random data in order to make sure we generate junk.
         self.insns_file = insns_file
 
+        # Generate a separate list of only vector extension instructions
+        self.pqc_insns = []
+        self.pqc_weights = []
+        for insn in insns_file.insns:
+            weight = cfg.insn_weights.get(insn.mnemonic)
+            if weight > 0:
+                if insn.pqc:
+                    self.pqc_insns.append(insn)
+                    self.pqc_weights.append(weight)
+
     def _get_badbits(self) -> int:
         for _ in range(50):
             data = random.getrandbits(32)
@@ -39,11 +49,66 @@ class BadInsn(SnippetGen):
         # assert that it doesn't happen.
         assert 0
 
+    def _gen_bad_pqc(self, model: Model):
+        weights = self.pqc_weights
+        prog_insn = None
+        while prog_insn is None:
+            idx = random.choices(range(len(self.pqc_insns)), weights=weights)[0]
+            assert weights[idx] > 0
+
+            # Try to fill out the instruction. On failure, clear the weight for
+            # this index and go around again. We take the copy here, rather
+            # than outside the loop, because we don't expect this to happen
+            # very often.
+            insn = self.pqc_insns[idx]
+            op_vals = []
+            for operand in insn.operands:
+                op_val = model.pick_operand_value(operand.op_type)
+
+                if op_val is None:
+                    return None
+
+                # Ensure a proper type enum for mulv/l
+                if (
+                    (insn.mnemonic == 'bn.mulv.l' or insn.mnemonic == "bn.mulv")
+                    and (len(op_vals) == len(insn.operands) - 1)
+                ):
+                    while operand.op_type.items[op_val] == '""':  # Empty enum index contain ""
+                        op_val = model.pick_operand_value(operand.op_type)
+
+                op_vals.append(op_val)
+
+            # If out of range lane index take modulo to fit in bounds
+            if (
+                insn.mnemonic == "bn.mulv.l"
+                and operand.op_type.items[op_vals[-1]].startswith(".8")
+                and op_vals[-2] >= 8
+            ):
+                op_vals[-2] = op_vals[-2] % 8
+
+            assert len(op_vals) == len(insn.operands)
+            prog_insn = ProgInsn(insn, op_vals, None)
+
+            if prog_insn is None:
+                weights = self.weights.copy()
+                weights[idx] = 0
+                continue
+
+        return prog_insn
+
     def gen(self,
             cont: GenCont,
             model: Model,
             program: Program) -> Optional[GenRet]:
-        prog_insn = DummyProgInsn(self._get_badbits())
+        # If PQC is enabled only random bit insn will be illegal
+        if model.pqc:
+            prog_insn = DummyProgInsn(self._get_badbits())
+        else:
+            # Otherwise randomly choose between random bit and vector insn
+            if random.choice([True, False]):
+                prog_insn = DummyProgInsn(self._get_badbits())
+            else:
+                prog_insn = self._gen_bad_pqc(model)
         snippet = ProgSnippet(model.pc, [prog_insn])
         snippet.insert_into_program(program)
         return (snippet, model)

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_ispr.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_ispr.py
@@ -1,4 +1,5 @@
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/hw/ip/otbn/dv/rig/rig/gens/bad_ispr.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/bad_ispr.py
@@ -30,7 +30,7 @@ class BadIspr(SnippetGen):
 
         for insn in insns_file.insns:
             # Pick only the instructions pertaining to CSR and WSR.
-            if insn.mnemonic not in ['csrrw', 'csrrs', 'wsrs', 'wsrw']:
+            if insn.mnemonic not in ['csrrw', 'csrrs', 'bn.wsrr', 'bn.wsrw']:
                 continue
 
             assert not (insn.python_pseudo_op or insn.literal_pseudo_op)

--- a/hw/ip/otbn/dv/rig/rig/model.py
+++ b/hw/ip/otbn/dv/rig/rig/model.py
@@ -228,7 +228,7 @@ class Model:
 
         # Known values for memory, keyed by memory type ('dmem', 'csr', 'wsr').
         csrs = KnownMem(4096)
-        wsrs = KnownMem(4096)
+        wsrs = KnownMem(256)
         self._known_mem = {
             'dmem': KnownMem(dmem_size),
             'csr': csrs,
@@ -241,6 +241,10 @@ class Model:
         csrs.touch_addr(0x7c8)      # FLAGS
         csrs.touch_range(0x7d0, 8)  # MOD0 - MOD7
         csrs.touch_addr(0x7d8)      # RND_PREFETCH
+        if self.pqc:
+            csrs.touch_addr(0x7d9)  # KMAC_CFG
+            csrs.touch_addr(0x7e2)  # KMAC_STATUS
+            csrs.touch_addr(0x7f3)  # KMAC_PW
         csrs.touch_addr(0xfc0)      # RND
         csrs.touch_addr(0xfc1)      # URND
 
@@ -252,7 +256,11 @@ class Model:
         wsrs.touch_addr(0x5)        # KEY_S0_H
         wsrs.touch_addr(0x6)        # KEY_S1_L
         wsrs.touch_addr(0x7)        # KEY_S1_H
-        wsrs.touch_addr(0xb)        # ACCH
+        if self.pqc:
+            wsrs.touch_addr(0x8)    # KMAC_CFG
+            wsrs.touch_addr(0x9)    # KMAC_MSG
+            wsrs.touch_addr(0xa)    # KMAC_DIGEST
+            wsrs.touch_addr(0xb)    # ACCH
 
         # Separate CSR list for KMAC as these should be off-limits from
         # non app_req generators, with the exception of MOD0
@@ -269,8 +277,7 @@ class Model:
             "MOD": 0x0,
             "KMAC_CFG": 0x8,
             "KMAC_MSG": 0x9,
-            "KMAC_DIGEST": 0xa,
-            "KMAC_PW": 0xb
+            "KMAC_DIGEST": 0xa
         }
 
         # The current PC (the address of the next instruction that needs

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -1554,6 +1554,11 @@ module otbn_controller
       end
       default: wsr_illegal_addr = 1'b1;
     endcase
+
+    // BN.WSRR/WSRW encoding allows 8-bit immediate but only declared WSR are valid
+    if (insn_dec_bignum_i.i[7:0] >= (1 << WsrNumWidth)) begin
+      wsr_illegal_addr = 1'b1;
+    end
   end
 
   assign wsr_wdata = insn_dec_shared_i.ispr_rs_insn ? ispr_rdata | rf_bignum_rd_data_a_no_intg :

--- a/hw/ip/otbn/rtl/otbn_predecode.sv
+++ b/hw/ip/otbn/rtl/otbn_predecode.sv
@@ -342,16 +342,22 @@ module otbn_predecode
             end
             3'b101: begin
               // BN.ADDM/BN.SUBM
-              rf_ren_a_bignum                = 1'b1;
-              rf_ren_b_bignum                = 1'b1;
-              rf_we_bignum                   = 1'b1;
-              alu_bignum_shift_amt           = shift_amt_a_type_bignum;
-              alu_bignum_adder_x_en          = 1'b1;
-              alu_bignum_x_res_operand_a_sel = 1'b1;
-              alu_bignum_shift_mod_sel       = 1'b0;
-              if (OtbnPQCEn) begin
-                alu_bignum_vector_type_pqc = alu_vector_type_t'(imem_rdata_i[27:26]);
-                alu_bignum_vector_sel_pqc  = imem_rdata_i[25];
+              // BN.ADDV/BN.SUBV are also predecoded here
+              // We check rdata[25] (Vector Enable) and OtbnPQCEn to make sure that predecode
+              // flags are only set for legal instructions.
+              // rdata[25] can not be 1 and OtbnPQCEn be 0
+              if (~imem_rdata_i[25] | OtbnPQCEn) begin
+                rf_ren_a_bignum                = 1'b1;
+                rf_ren_b_bignum                = 1'b1;
+                rf_we_bignum                   = 1'b1;
+                alu_bignum_shift_amt           = shift_amt_a_type_bignum;
+                alu_bignum_adder_x_en          = 1'b1;
+                alu_bignum_x_res_operand_a_sel = 1'b1;
+                alu_bignum_shift_mod_sel       = 1'b0;
+                if (OtbnPQCEn) begin
+                  alu_bignum_vector_type_pqc = alu_vector_type_t'(imem_rdata_i[27:26]);
+                  alu_bignum_vector_sel_pqc  = imem_rdata_i[25];
+                end
               end
             end
             default: ;

--- a/hw/ip/otbn/util/otbn_sim_test.py
+++ b/hw/ip/otbn/util/otbn_sim_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -93,6 +94,9 @@ def main() -> int:
                         metavar='FILE',
                         type=argparse.FileType('r'),
                         help='Path to a testcase hjson file.')
+    parser.add_argument('--pqc',
+                        action='store_true',
+                        help='Enable PQC mode for the simulator.')
     parser.add_argument('elf',
                         help='Path to the .elf file for the OTBN program.')
     parser.add_argument('-v', '--verbose', action='store_true')
@@ -114,6 +118,12 @@ def main() -> int:
         cmd_flags.extend([
             "--testcase",
             args.testcase.name,
+        ])
+
+    if args.pqc:
+        cmd_flags.extend([
+            "--pqc",
+            "-",
         ])
 
     with tempfile.NamedTemporaryFile() as regs_file, tempfile.NamedTemporaryFile() as dmem_file:

--- a/rules/otbn.bzl
+++ b/rules/otbn.bzl
@@ -1,8 +1,9 @@
 # Copyright lowRISC contributors (OpenTitan project).
-# Licensed under the Apache License, Version 2.0, see LICENSE for details.
-# SPDX-License-Identifier: Apache-2.0
 # Modified by Authors of "Towards ML-KEM & ML-DSA on OpenTitan" (https://eprint.iacr.org/2024/1192).
 # Copyright "Towards ML-KEM & ML-DSA on OpenTitan" Authors.
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
 
 load("//rules:rv.bzl", "rv_rule")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
@@ -160,7 +161,7 @@ def _otbn_binary(ctx, additional_srcs = []):
         ),
     ]
 
-def _run_sim_test(ctx, exp, dexp, testcase = None, additional_srcs = []):
+def _run_sim_test(ctx, exp, dexp, pqc, testcase = None, additional_srcs = []):
     providers = _otbn_binary(ctx, additional_srcs)
 
     # Extract the output .elf file from the output group.
@@ -172,13 +173,15 @@ def _run_sim_test(ctx, exp, dexp, testcase = None, additional_srcs = []):
         exp_content += "--expected_regs {} ".format(exp.short_path)
         exp_files.append(exp)
     if dexp != None:
-        exp_content += "--expected_dmem {}".format(dexp.short_path)
+        exp_content += "--expected_dmem {} ".format(dexp.short_path)
         exp_files.append(dexp)
     if testcase != None:
         if exp != None or dexp != None:
             fail("Testcase with legacy exp or dexp specified.")
         exp_content += "--testcase {} ".format(testcase.short_path)
         exp_files.append(testcase)
+    if pqc:
+        exp_content += "--pqc "
 
     # Create a simple script that runs the OTBN test wrapper on the .elf file
     # using the provided simulator path.
@@ -207,7 +210,7 @@ def _otbn_sim_test(ctx):
     them on the simulator. Tests are expected to count failures in the w0
     register; the test checks that w0=0 to determine if the test passed.
     """
-    return _run_sim_test(ctx, ctx.file.exp, ctx.file.dexp, testcase = ctx.file.testcase)
+    return _run_sim_test(ctx, ctx.file.exp, ctx.file.dexp, ctx.attr.pqc, testcase = ctx.file.testcase)
 
 def otbn_sim_test_suite(name, tests, **kwargs):
     def testname(target):
@@ -256,7 +259,7 @@ def _otbn_autogen_sim_test_impl(ctx):
         executable = ctx.executable.testgen,
     )
 
-    return _run_sim_test(ctx, exp, None, additional_srcs = [data])
+    return _run_sim_test(ctx, exp, None, ctx.attr.pqc, additional_srcs = [data])
 
 def _otbn_consttime_test_impl(ctx):
     """This rule checks if a program or subroutine is constant-time.
@@ -418,6 +421,7 @@ otbn_sim_test = rv_rule(
         "dexp": attr.label(allow_single_file = True),
         "testcase": attr.label(allow_single_file = True),
         "copts": attr.string_list(),
+        "pqc": attr.bool(default = False),
         "_riscv32_ar": attr.label(
             default = Label("@lowrisc_rv32imcb_toolchain//:bin/riscv32-unknown-elf-ar"),
             allow_single_file = True,
@@ -485,6 +489,7 @@ otbn_autogen_sim_test = rv_rule(
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = [DefaultInfo]),
         "copts": attr.string_list(),
+        "pqc": attr.bool(default = False),
         "_riscv32_ar": attr.label(
             default = Label("@lowrisc_rv32imcb_toolchain//:bin/riscv32-unknown-elf-ar"),
             allow_single_file = True,

--- a/sw/otbn/crypto/tests/mldsa/BUILD
+++ b/sw/otbn/crypto/tests/mldsa/BUILD
@@ -24,6 +24,7 @@ otbn_sim_test(
         "-DDILITHIUM_MODE=2",
     ],
     dexp = "dilithium2_keypair_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mldsa:intt",
         "//sw/otbn/crypto/mldsa:kmac_send_msg",
@@ -45,6 +46,7 @@ otbn_sim_test(
         "-DDILITHIUM_MODE=2",
     ],
     dexp = "dilithium2_sign_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mldsa:intt",
         "//sw/otbn/crypto/mldsa:kmac_send_msg",
@@ -67,6 +69,7 @@ otbn_sim_test(
         "-DDILITHIUM_MODE=2",
     ],
     dexp = "dilithium2_verify_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mldsa:intt",
         "//sw/otbn/crypto/mldsa:kmac_send_msg",
@@ -89,6 +92,7 @@ otbn_sim_test(
         "-DDILITHIUM_MODE=3",
     ],
     dexp = "dilithium3_keypair_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mldsa:intt",
         "//sw/otbn/crypto/mldsa:kmac_send_msg",
@@ -110,6 +114,7 @@ otbn_sim_test(
         "-DDILITHIUM_MODE=3",
     ],
     dexp = "dilithium3_sign_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mldsa:intt",
         "//sw/otbn/crypto/mldsa:kmac_send_msg",
@@ -132,6 +137,7 @@ otbn_sim_test(
         "-DDILITHIUM_MODE=3",
     ],
     dexp = "dilithium3_verify_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mldsa:intt",
         "//sw/otbn/crypto/mldsa:kmac_send_msg",
@@ -154,6 +160,7 @@ otbn_sim_test(
         "-DDILITHIUM_MODE=5",
     ],
     dexp = "dilithium5_keypair_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mldsa:intt",
         "//sw/otbn/crypto/mldsa:kmac_send_msg",
@@ -175,6 +182,7 @@ otbn_sim_test(
         "-DDILITHIUM_MODE=5",
     ],
     dexp = "dilithium5_sign_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mldsa:intt",
         "//sw/otbn/crypto/mldsa:kmac_send_msg",
@@ -197,6 +205,7 @@ otbn_sim_test(
         "-DDILITHIUM_MODE=5",
     ],
     dexp = "dilithium5_verify_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mldsa:intt",
         "//sw/otbn/crypto/mldsa:kmac_send_msg",
@@ -221,6 +230,7 @@ otbn_sim_test(
         "-DDILITHIUM_MODE=2",
     ],
     dexp = "poly_uniform_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mldsa:kmac_send_msg",
         "//sw/otbn/crypto/mldsa:mldsa44_poly",
@@ -239,6 +249,7 @@ otbn_sim_test(
         "-DDILITHIUM_MODE=2",
     ],
     dexp = "poly_uniform_postprocess_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mldsa:kmac_send_msg",
         "//sw/otbn/crypto/mldsa:mldsa44_poly",

--- a/sw/otbn/crypto/tests/mlkem/BUILD
+++ b/sw/otbn/crypto/tests/mlkem/BUILD
@@ -20,6 +20,7 @@ otbn_sim_test(
         "-DKYBER_K=2",
     ],
     dexp = "mlkem512_keypair_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mlkem:basemul",
         "//sw/otbn/crypto/mlkem:cbd",
@@ -41,6 +42,7 @@ otbn_sim_test(
         "-DKYBER_K=2",
     ],
     dexp = "mlkem512_encap_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mlkem:basemul",
         "//sw/otbn/crypto/mlkem:cbd",
@@ -64,6 +66,7 @@ otbn_sim_test(
         "-DKYBER_K=2",
     ],
     dexp = "mlkem512_decap_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mlkem:basemul",
         "//sw/otbn/crypto/mlkem:cbd",
@@ -88,6 +91,7 @@ otbn_sim_test(
         "-DKYBER_K=2",
     ],
     dexp = "mlkem512_false_decap_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mlkem:basemul",
         "//sw/otbn/crypto/mlkem:cbd",
@@ -112,6 +116,7 @@ otbn_sim_test(
         "-DKYBER_K=3",
     ],
     dexp = "mlkem768_keypair_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mlkem:basemul",
         "//sw/otbn/crypto/mlkem:cbd",
@@ -133,6 +138,7 @@ otbn_sim_test(
         "-DKYBER_K=3",
     ],
     dexp = "mlkem768_encap_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mlkem:basemul",
         "//sw/otbn/crypto/mlkem:cbd",
@@ -156,6 +162,7 @@ otbn_sim_test(
         "-DKYBER_K=3",
     ],
     dexp = "mlkem768_decap_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mlkem:basemul",
         "//sw/otbn/crypto/mlkem:cbd",
@@ -180,6 +187,7 @@ otbn_sim_test(
         "-DKYBER_K=3",
     ],
     dexp = "mlkem768_false_decap_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mlkem:basemul",
         "//sw/otbn/crypto/mlkem:cbd",
@@ -204,6 +212,7 @@ otbn_sim_test(
         "-DKYBER_K=4",
     ],
     dexp = "mlkem1024_keypair_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mlkem:basemul",
         "//sw/otbn/crypto/mlkem:cbd",
@@ -225,6 +234,7 @@ otbn_sim_test(
         "-DKYBER_K=4",
     ],
     dexp = "mlkem1024_encap_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mlkem:basemul",
         "//sw/otbn/crypto/mlkem:cbd",
@@ -248,6 +258,7 @@ otbn_sim_test(
         "-DKYBER_K=4",
     ],
     dexp = "mlkem1024_decap_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mlkem:basemul",
         "//sw/otbn/crypto/mlkem:cbd",
@@ -272,6 +283,7 @@ otbn_sim_test(
         "-DKYBER_K=4",
     ],
     dexp = "mlkem1024_false_decap_test.dexp",
+    pqc = True,
     deps = [
         "//sw/otbn/crypto/mlkem:basemul",
         "//sw/otbn/crypto/mlkem:cbd",


### PR DESCRIPTION
This PR expands the verification capabilities to try and cover previously unreachable states by allowing the generation of the PQC vector instructions and mode specific WSR/CSR registers. Previously illegal instructions were made of 32 random bits. Now they are legitimate vector instructions (bn.shv, bn.addv, etc) but generated when the PQC parameter is `0` in order to test illegal instruction handling in OTBN.

#### Illegal Instructions

- Conditionally added the generation of PQC specific vector instructions to the `bad_insn.py` generator for when `OtbnPQCEn` is `0`.
- Added an illegal instruction check in `insn.py` based on the PQC environment variable.
- Fixed a bug in `otbn_predecode.sv` due to the vector instructions `bn.addv` and `bn.subv` sharing an opcode with non-vector instructions `bn.add` and `bn.sub` leading to the `illegal_insn` flag being raised improperly.

#### Illegal ISPR
It was discovered that the `bad_ispr.py` generator meant to create illegal csr/wsr accesses was not generating any WSR instructions, `bn.wsrr or bn.wsrw` due to incorrectly naming the mnemonic. Additionally the RTL had a bug where only the bits required to represent the addresses of the valid WSR were being truncated from the immediate field, this allowed for the RTL to read/write illegally to real WSR if the lower 4-bits of the immediate mapped to an actual WSR, regardless of the MSB values.

- Removed unused CSR registers from the `csr.py` file and added CSR/WSR register enables based on the PQC environment variable.
- Fixed problems in `bad_ispr.py` to allow illegal address WSR instructions to be generated.
- Fixed bug in RTL to prevent illegal access to WSR.