### PR TITLE
[mldsa] More performance improvements for poly_uniform.

### DIFF
--- a/sw/otbn/crypto/mldsa/mldsa_keypair.s
+++ b/sw/otbn/crypto/mldsa/mldsa_keypair.s
@@ -268,7 +268,7 @@ crypto_sign_keypair:
     /* Initialize the nonce for matrix expansion. This value should be
          byte(i) || byte(j)
        for entry A[i][j]. */
-    li s4, 0
+    bn.xor w23, w23, w23
 
     /* Load pointer to twiddle factors for NTT */
     la  s5, twiddles_fwd
@@ -282,6 +282,11 @@ crypto_sign_keypair:
     lw   s7, 0(t1)
     addi s7, s7, 128
 
+    /* Precompute the SHAKE128 configuration for poly_uniform. */
+    addi  s4, zero, 34
+    slli  s4, s4, 5
+    addi  s4, s4, SHAKE128_CFG
+
     /* Compute A * s1, computing elements of A on the fly.
 
        We compute column-wise so that we generate elements of s1 only once; in
@@ -292,7 +297,7 @@ crypto_sign_keypair:
            for i in 0..k-1:
              t[i] += A[i][j] * s1j
     */
-    loopi L, 29
+    loopi L, 38
         bn.wsrw   mod, w16 /* MOD = R | Q */
         /* Sample the next polynomial from s1. */
         addi a0, fp, STACK_RHOPRIME
@@ -300,6 +305,12 @@ crypto_sign_keypair:
         addi a2, s6, 0
         jal  x1, poly_uniform_eta
         addi s6, s6, 1
+        /* Start the SHAKE128 operation for poly_uniform for A[0][j]. */
+        csrrw zero, kmac_cfg, s4
+        addi  a0, fp, STACK_RHO
+        bn.lid    x0, 0(a0)
+        bn.wsrw   kmac_msg, w0
+        bn.wsrw   kmac_msg, w23
         /* Pack the s1 polynomial into the secret key. */
         addi a0, s7, 0
         addi a1, s0, 0
@@ -311,14 +322,18 @@ crypto_sign_keypair:
         addi a1, s5, 0
         addi a2, s0, 0
         jal  x1, ntt
-        loopi K, 10
+        loopi K, 13
             /* Compute A[i][j]. */
-            addi a0, fp, STACK_RHO
             addi a1, s1, 0
-            addi a2, s4, 0
             jal  x1, poly_uniform
             /* Increment the row in the matrix nonce (upper byte). */
-            addi s4, s4, 256
+            bn.addi w23, w23, 256
+            /* Start the SHAKE128 operation for poly_uniform for A[i+1][j]. */
+            csrrw zero, kmac_cfg, s4
+            addi  a0, fp, STACK_RHO
+            bn.lid    x0, 0(a0)
+            bn.wsrw   kmac_msg, w0
+            bn.wsrw   kmac_msg, w23
             /* Compute A[i][j] * s1[j] and add it to the output at index i. */
             addi a0, s0, 0
             addi a1, s1, 0
@@ -329,9 +344,10 @@ crypto_sign_keypair:
         /* Reset output vector pointer. */
         sub  s2, s2, s3
         /* Increment the column index in the nonce by one. */
-        addi s4, s4, 1
+        bn.addi w23, w23, 1
         /* Reset the row index in the nonce to zero. */
-        andi s4, s4, 255
+        bn.rshi w23, w23, bn0 >> 8
+        bn.rshi w23, bn0, w23 >> 248
 
     /* After poly_pointwise, w16 is still R | Q and MOD is still 2*R | 2*Q */
     /* Inverse NTT on t=A*s1 */

--- a/sw/otbn/crypto/mldsa/mldsa_sign.s
+++ b/sw/otbn/crypto/mldsa/mldsa_sign.s
@@ -497,7 +497,7 @@ _rej_crypto_sign_signature_internal:
     /* Initialize the nonce for matrix expansion. This value should be
          byte(i) || byte(j)
        for entry A[i][j]. */
-    li s4, 0
+    bn.xor w23, w23, w23
 
     /* Load a constant pointer to the zero wide register. */
     li s5, 31
@@ -514,6 +514,11 @@ _rej_crypto_sign_signature_internal:
     li   s10, STACK_TMP
     add  s10, fp, s10
 
+    /* Precompute the SHAKE128 configuration for poly_uniform. */
+    addi  s4, zero, 34
+    slli  s4, s4, 5
+    addi  s4, s4, SHAKE128_CFG
+
     /* Compute A * y, computing the values for A and y on the fly.
 
        We compute column-wise so that we genearate elements of y only once; in
@@ -524,7 +529,7 @@ _rej_crypto_sign_signature_internal:
            for i in 0..k-1:
              w[i] += A[i][j] * yj
     */
-    loopi L, 29
+    loopi L, 38
         /* Zero the buffer for y[j]. */
         addi  t0, s8, 0
         loopi 32, 1
@@ -536,18 +541,30 @@ _rej_crypto_sign_signature_internal:
         addi a3, s7, 0
         jal  x1, poly_uniform_gamma_1
         addi s11, a2, 1 /* a2 should be preserved after execution */
+        /* Start the SHAKE128 operation for poly_uniform for A[0][j]. */
+        csrrw zero, kmac_cfg, s4
+        addi  a0, fp, STACK_RHO
+        bn.lid    x0, 0(a0)
+        bn.wsrw   kmac_msg, w0
+        bn.wsrw   kmac_msg, w23
         bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */
         /* Compute ntt(y[j]). */
         addi a0, s8, 0
         addi a1, s9, 0
         addi a2, s8, 0
         jal x1, ntt
-        loopi K, 10
+        loopi K, 13
             /* Compute A[i][j]. */
-            addi a0, fp, STACK_RHO
             addi a1, s10, 0
-            addi a2, s4, 0 /* matrix nonce */
             jal  x1, poly_uniform
+            /* Increment the row index by 1. */
+            bn.addi w23, w23, 256
+            /* Start the SHAKE128 operation for poly_uniform for A[i+1][j]. */
+            csrrw zero, kmac_cfg, s4
+            addi  a0, fp, STACK_RHO
+            bn.lid    x0, 0(a0)
+            bn.wsrw   kmac_msg, w0
+            bn.wsrw   kmac_msg, w23
             addi a0, s8, 0
             addi a1, s10, 0
             addi a2, s1, 0 /* *w[i] */
@@ -555,14 +572,13 @@ _rej_crypto_sign_signature_internal:
             jal  x1, poly_pointwise_acc
             /* Increment the w pointer. */
             addi s1, s1, 1024
-            /* Increment the row index by 1. */
-            addi s4, s4, 256
         /* Reset w pointer. */
         sub  s1, s1, s6
         /* Increment the column index in the nonce by one. */
-        addi s4, s4, 1
+        bn.addi w23, w23, 1
         /* Reset the row index in the nonce to zero. */
-        andi s4, s4, 255
+        bn.rshi w23, w23, bn0 >> 8
+        bn.rshi w23, bn0, w23 >> 248
         bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
 
     bn.wsrw 0x0, mod_x2 /* MOD = 2*R | 2*Q */

--- a/sw/otbn/crypto/mldsa/mldsa_verify.s
+++ b/sw/otbn/crypto/mldsa/mldsa_verify.s
@@ -529,6 +529,23 @@ crypto_sign_verify_internal:
         pop \reg
     .endr
 
+    /* Initialize the nonce for matrix expansion. This value should be
+         byte(i) || byte(j)
+       for entry A[i][j]. */
+    bn.xor w23, w23, w23
+
+    /* Precompute the SHAKE128 configuration for poly_uniform. */
+    addi  s4, zero, 34
+    slli  s4, s4, 5
+    addi  s4, s4, SHAKE128_CFG
+
+    /* Start the SHAKE computation for A[0][0] ahead of NTT for performance. */
+    csrrw zero, kmac_cfg, s4
+    addi  a0, fp, STACK_RHO
+    bn.lid    x0, 0(a0)
+    bn.wsrw   kmac_msg, w0
+    bn.wsrw   kmac_msg, w23
+
     /* After NTT(z), w16 is still R | Q and MOD is still 2*R | 2*Q */
     /* NTT(c) */
     li   a0, STACK_CP
@@ -562,34 +579,37 @@ crypto_sign_verify_internal:
     /* Load offset for resetting vector pointer. */
     li s3, POLYVECL_BYTES
 
-    /* Initialize the nonce for matrix expansion. This value should be
-         byte(i) || byte(j)
-       for entry A[i][j]. */
-    li s4, 0
-
      /* Compute A * z, computing elements of A on the fly. */
-    loopi K, 25
-        /* Compute A[i][j]. */
-        addi a0, fp, STACK_RHO
+    loopi K, 36
+        /* Compute A[i][0]. */
         addi a1, s1, 0
-        addi a2, s4, 0
         jal  x1, poly_uniform
         /* Increment the matrix nonce. */
-        addi s4, s4, 1
-        /* Compute A[i][j] * z[j] and set the output at index i. */
+        bn.addi w23, w23, 1
+        /* Start the SHAKE128 operation for poly_uniform for A[i][1]. */
+        csrrw zero, kmac_cfg, s4
+        addi  a0, fp, STACK_RHO
+        bn.lid    x0, 0(a0)
+        bn.wsrw   kmac_msg, w0
+        bn.wsrw   kmac_msg, w23
+        /* Compute A[i][0] * z[0] and set the output at index i. */
         addi a0, s0, 0
         addi a1, s1, 0
         addi a2, s2, 0
         jal  x1, poly_pointwise
         addi s0, s0, 1024
-        loopi Lminus1, 10
+        loopi Lminus1, 13
             /* Compute A[i][j]. */
-            addi a0, fp, STACK_RHO
             addi a1, s1, 0
-            addi a2, s4, 0
             jal  x1, poly_uniform
             /* Increment the matrix nonce. */
-            addi s4, s4, 1
+            bn.addi w23, w23, 1
+            /* Start the SHAKE128 operation for poly_uniform for A[i][j+1]. */
+            csrrw zero, kmac_cfg, s4
+            addi  a0, fp, STACK_RHO
+            bn.lid    x0, 0(a0)
+            bn.wsrw   kmac_msg, w0
+            bn.wsrw   kmac_msg, w23
             /* Compute A[i][j] * z[j] and add it to the output at index i. */
             addi a0, s0, 0
             addi a1, s1, 0
@@ -600,8 +620,14 @@ crypto_sign_verify_internal:
         sub  s0, s0, s3
         addi s2, s2, 1024
         /* Adjust the matrix nonce to reset the column and increment the row. */
-        addi s4, s4, 256
-        addi s4, s4, -L
+        bn.addi w23, w23, 256
+        bn.subi w23, w23, L
+        /* Start the SHAKE128 operation for poly_uniform for A[i+1][j]. */
+        csrrw zero, kmac_cfg, s4
+        addi  a0, fp, STACK_RHO
+        bn.lid    x0, 0(a0)
+        bn.wsrw   kmac_msg, w0
+        bn.wsrw   kmac_msg, w23
 
     /* Call random oracle and verify challenge */
     /* Initialize a SHAKE256 operation. */

--- a/sw/otbn/crypto/mldsa/poly.s
+++ b/sw/otbn/crypto/mldsa/poly.s
@@ -646,39 +646,20 @@ _loop_inner_skip_load_poly_challenge:
 /**
  * poly_uniform
  *
- * Returns: -
+ * Rejection-samples SHAKE output for a full polynomial of coefficients < Q.
+ *
+ * Expects the SHAKE operation to have already been initialized before this
+ * function is called.
  *
  * Flags: Clobbers FG0, has no meaning beyond the scope of this subroutine.
  *
- * @param[in]  a0: pointer to rho
- * @param[in]  a2: nonce
- * @param[out] a1: dmem pointer to polynomial
+ * @param[in] a1: dmem pointer to polynomial
+ * @param[out] dmem[a1]: freshly sampled polynomial
  *
- * clobbered registers: a0-a3, t0-t6, w0, w8-w13, w21
+ * clobbered registers: a0-a3, t0-t6, w0, w8-w15, w21
  */
 .global poly_uniform
 poly_uniform:
-    /* Save nonce to memory (use poly tmp buffer). */
-    la t0, poly_wdr2gpr
-    sw a2, 0(t0)
-
-    /* TODO: Start the operation outside the function. */
-    /* Initialize a SHAKE128 operation. */
-    addi  a3, a1, 0               /* save output pointer */
-    addi  a1, zero, 34
-    slli  t0, a1, 5
-    addi  t0, t0, SHAKE128_CFG
-    csrrw zero, KECCAK_CFG_REG, t0
-
-    /* Send the message to the Keccak core. */
-    li   a1, 32                  /* set message length */
-    jal  x1, keccak_send_message /* a0 already contains the input buffer */
-    addi a1, zero, 2             /* set message length */
-    la   a0, poly_wdr2gpr        /* Set a0 to point to the nonce in memory */
-    jal  x1, keccak_send_message
-
-    addi a1, a3, 0 /* move output pointer back to a1 */
-
     /* Define temporary registers. */
     #define shake_reg w8
     #define shake_reg_ptr 8

--- a/sw/otbn/crypto/mldsa/poly.s
+++ b/sw/otbn/crypto/mldsa/poly.s
@@ -732,15 +732,17 @@ poly_uniform:
     /* Read 32 bytes from the digest. */
     bn.wsrr shake_reg, kmac_digest
     /* Load 8 23-bit coefficient candidates into vector register. */
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     /* Store 8 coefficient candidates. */
     bn.sid  x0, 0(a1++)
     /* Load 2 23-bit coefficient candidates into vector register. */
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     /* Save the leftover bytes (2) in the upper part of w0. */
     bn.rshi w0, shake_reg, w0 >> 16
     /* Read 32 bytes from the digest. */
@@ -749,15 +751,17 @@ poly_uniform:
     bn.rshi w0, shake_reg, w0 >> 16
     bn.rshi shake_reg, shake_reg, shake_reg >> 8
     /* Load 5 23-bit coefficient candidates into vector register. */
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     /* Store 8 coefficient candidates. */
     bn.sid  x0, 0(a1++)
     /* Load 5 23-bit coefficient candidates into vector register. */
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     /* Save the leftover bytes (1) in the upper part of w0. */
     bn.rshi w0, shake_reg, w0 >> 8
     /* Read 32 bytes from the digest. */
@@ -766,39 +770,45 @@ poly_uniform:
     bn.rshi w0, shake_reg, w0 >> 24
     bn.rshi shake_reg, shake_reg, shake_reg >> 16
     /* Load 2 23-bit coefficient candidates into vector register. */
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     /* Store 8 coefficient candidates. */
     bn.sid  x0, 0(a1++)
     /* Load 8 23-bit coefficient candidates into vector register. */
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     /* Store 8 coefficient candidates. */
     bn.sid  x0, 0(a1++)
 
     /* Process bytes 96..191 of digest (state refresh before third read). */
 
     bn.wsrr shake_reg, kmac_digest
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 16
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 16
     bn.rshi shake_reg, shake_reg, shake_reg >> 8
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 8
     /* While waiting for more digest, mask and check vectors 0..5. */
     li      t1, 6
@@ -807,59 +817,69 @@ poly_uniform:
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 24
     bn.rshi shake_reg, shake_reg, shake_reg >> 16
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
 
     /* Process bytes 192-287 of digest (no state refresh needed). */
 
     bn.wsrr shake_reg, kmac_digest
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 16
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 16
     bn.rshi shake_reg, shake_reg, shake_reg >> 8
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 8
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 24
     bn.rshi shake_reg, shake_reg, shake_reg >> 16
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
 
     /* Process bytes 288-383 of digest (state refresh before second read). */
 
     bn.wsrr shake_reg, kmac_digest
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 16
     /* While waiting for more digest, mask and check vectors 6..12. */
     li      t1, 7
@@ -868,58 +888,68 @@ poly_uniform:
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 16
     bn.rshi shake_reg, shake_reg, shake_reg >> 8
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 8
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 24
     bn.rshi shake_reg, shake_reg, shake_reg >> 16
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
 
     /* Process bytes 384-479 of digest (no state refresh needed). */
 
     bn.wsrr shake_reg, kmac_digest
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 16
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 16
     bn.rshi shake_reg, shake_reg, shake_reg >> 8
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 8
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 24
     bn.rshi shake_reg, shake_reg, shake_reg >> 16
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
 
     /* Process bytes 480-575 of digest (state refresh before first read). */
@@ -940,69 +970,81 @@ poly_uniform:
       bn.add     w14, w14, w15
     /* STATE REFRESH. */
     bn.wsrr shake_reg, kmac_digest
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 16
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 16
     bn.rshi shake_reg, shake_reg, shake_reg >> 8
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 8
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 24
     bn.rshi shake_reg, shake_reg, shake_reg >> 16
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
 
     /* Process bytes 576-671 of digest (no state refresh needed). */
 
     bn.wsrr shake_reg, kmac_digest
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 16
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 16
     bn.rshi shake_reg, shake_reg, shake_reg >> 8
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 8
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 24
     bn.rshi shake_reg, shake_reg, shake_reg >> 16
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
 
     /* Process bytes 672-767 of digest (state refresh before first read). */
@@ -1024,35 +1066,41 @@ poly_uniform:
       bn.add     w14, w14, w15
     /* STATE REFRESH. */
     bn.wsrr shake_reg, kmac_digest
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 16
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 16
     bn.rshi shake_reg, shake_reg, shake_reg >> 8
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   5, 2
+    .rept 5
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.rshi w0, shake_reg, w0 >> 8
     bn.wsrr shake_reg, kmac_digest
     bn.rshi w0, shake_reg, w0 >> 24
     bn.rshi shake_reg, shake_reg, shake_reg >> 16
-    loopi   2, 2
+    .rept 2
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
-    loopi   8, 2
+    .rept 8
       bn.rshi w0, shake_reg, w0 >> 32
       bn.rshi shake_reg, shake_reg, shake_reg >> 24
+    .endr
     bn.sid  x0, 0(a1++)
 
     /* Done sampling; mask and check the last few vectors 28..31. */

--- a/sw/otbn/crypto/mldsa/poly.s
+++ b/sw/otbn/crypto/mldsa/poly.s
@@ -943,12 +943,20 @@ poly_uniform:
 
     /* Process bytes 480-575 of digest (state refresh before first read). */
 
-    /* While waiting for more digest, mask and check vectors 13..19. Note that
-       t1 already holds the right vector count from the previous check (and for
-       this run in particular we actually exceed the SHAKE latency due to the
-       larger amount of computation between the last shake read and this one,
-       so saving the instruction counts). */
-    jal     x1, poly_uniform_mask_and_check_vectors
+    /* Note: this loop is an inlined version of
+       poly_uniform_mask_and_check_vectors, because when there is a refresh on
+       the first read of a 96-byte cycle the checking latency slightly exceeds
+       the SHAKE latency and saving a few instructions on loading the loop size
+       and jumping actually counts. */
+    loopi  7, 8
+      bn.lid     t6, 0(t3)
+      bn.and     w21, w21, w11
+      bn.sid     t6, 0(t3++)
+      bn.subv.8S w10, w21, w12
+      bn.and     w10, w10, w13
+      bn.cmp     w10, w13
+      bn.sel     w15, w15, bn0, Z
+      bn.add     w14, w14, w15
     /* STATE REFRESH. */
     bn.wsrr shake_reg, kmac_digest
     loopi   8, 2
@@ -1019,8 +1027,20 @@ poly_uniform:
     /* Process bytes 672-767 of digest (state refresh before first read). */
 
     /* While waiting for more digest, mask and check vectors 20..27. */
-    li      t1, 8
-    jal     x1, poly_uniform_mask_and_check_vectors
+    /* Note: this loop is an inlined version of
+       poly_uniform_mask_and_check_vectors, because when there is a refresh on
+       the first read of a 96-byte cycle the checking latency slightly exceeds
+       the SHAKE latency and saving a few instructions on loading the loop size
+       and jumping actually counts. */
+    loopi  8, 8
+      bn.lid     t6, 0(t3)
+      bn.and     w21, w21, w11
+      bn.sid     t6, 0(t3++)
+      bn.subv.8S w10, w21, w12
+      bn.and     w10, w10, w13
+      bn.cmp     w10, w13
+      bn.sel     w15, w15, bn0, Z
+      bn.add     w14, w14, w15
     /* STATE REFRESH. */
     bn.wsrr shake_reg, kmac_digest
     loopi   8, 2
@@ -1151,8 +1171,7 @@ _poly_uniform_discard_coeff_skip_shift:
     /* Speculatively copy 3 bytes of digest (some bytes may be invalid). */
     bn.rshi w0, shake_reg, w0 >> 32
     bn.rshi shake_reg, shake_reg, shake_reg >> 24
-    /* Speculatively mask and store. */
-    bn.and  w0, w0, w11
+    /* Speculatively store. */
     bn.sid  zero, 0(t0)
     /* Update number of bytes available and check for underflow. If the bytes
        were all valid, we're done. */
@@ -1176,8 +1195,7 @@ _poly_uniform_discard_coeff_skip_shift:
     bn.rshi w0, bn0, w0 >> 8
     /* Update the number of bytes available in the digest. */
     addi    t2, t2, 32
-    /* Re-mask and re-store. */
-    bn.and  w0, w0, w11
+    /* Store again. */
     bn.sid  zero, 0(t0)
 _poly_uniform_recompute_first_bad_index:
     /* Calculate the number of vectors remaining (includes the just-corrected

--- a/sw/otbn/crypto/tests/mldsa/poly_uniform_test.s
+++ b/sw/otbn/crypto/tests/mldsa/poly_uniform_test.s
@@ -12,10 +12,18 @@ main:
   /* Prepare all-zero register. */
   bn.xor w31, w31, w31
 
-  /* Call poly_uniform with an all-zero input. */
-  la  x10, rho
+  /* Set up the SHAKE128 configuration for poly_uniform. */
+  addi  x2, zero, 34
+  slli  x2, x2, 5
+  addi  x2, x2, 0x2 /* SHAKE128 */
+  csrrw x0, kmac_cfg, x2
+
+  /* Send the input (34 zero bytes) */
+  bn.wsrw   kmac_msg, w31
+  bn.wsrw   kmac_msg, w31
+
+  /* Call poly_uniform. */
   la  x11, result
-  li  x12, 0
   jal x1, poly_uniform
 
   ecall


### PR DESCRIPTION
Follow-up to #43 

The biggest change here is initializing the SHAKE computation outside of `poly_uniform` itself, so we can get fewer stalls for the first iteration. I also inlined a few loops to save control-flow cycles.

Overall speedup for top-level ML-DSA operations is 2.5-5% (based on a benchmarking setup I haven't yet merged that averages cycle counts for 100 random tests).
```
ML-DSA-44 keygen:  93086 ->  90037 (-3049,  -3.28%)
ML-DSA-44 sign:   561052 -> 546878 (-14174, -2.53%)
ML-DSA-44 verify:  84932 ->  82209 (-2723,  -3.21%)

ML-DSA-65 keypair: 160462 -> 154725 (-5737,  -3.58%)
ML-DSA-65 sign:   1013441 -> 981085 (-32356, -3.19%)
ML-DSA-65 verify:  128981 -> 123792 (-5189,  -4.02%)

ML-DSA-87 keypair: 224279 ->  213553 (-10726, -4.78%)
ML-DSA-87 sign:   1209624 -> 1163922 (-45702, -3.78%)
ML-DSA-87 verify:  202533 ->  192567 (-9966,  -4.92%)
```

This is the last PR in the `poly_uniform` optimization series, I think.