### PR TITLE
[mlkem] Separate SHAKE inits from poly_getnoise_eta_* for performance

### DIFF
--- a/sw/otbn/crypto/mlkem/mlkem_encap.s
+++ b/sw/otbn/crypto/mlkem/mlkem_encap.s
@@ -209,6 +209,14 @@ indcpa_enc:
   add a2, fp, a2
   jal x1, poly_frommsg
 
+  /* Prepare for initial `poly_getnoise_eta_1` call, performing the SHAKE
+     computation during `unpack_pk` */
+  lw   a0, STACK_ENC_COINS_ADDR(fp)
+  li   a3, STACK_ENC_NONCE
+  li   t0, 0
+  sw   t0, STACK_ENC_NONCE(fp)
+  jal  x1, poly_getnoise_eta_init
+
   /*** unpack_pk ***/
   lw  a0, STACK_ENC_PK_ADDR(fp)
   la  a3, const_0x0fff
@@ -219,32 +227,53 @@ indcpa_enc:
   bn.lid x4, 0(a0)
   bn.sid x4, STACK_ENC_SEED(fp)
 
-  /*** CBD sp ***/
-  lw  a0, STACK_ENC_COINS_ADDR(fp)
-  add a4, zero, a0
-  li  a1, STACK_ENC_SP
-  add a1, fp, a1
-  li  a5, STACK_ENC_V
-  li  a3, STACK_ENC_NONCE
-  li  a2, 0
-  LOOPI KYBER_K, 5
-    add  t1, fp, a5
-    sw   a2, STACK_ENC_NONCE(fp)
+  /*** CBD sp + NTT ***/
+  li  s8, STACK_ENC_NONCE
+  lw  s9, STACK_ENC_COINS_ADDR(fp)
+  li  s10, STACK_ENC_SP
+  add s10, fp, s10
+  li  s11, 0
+
+  .rept KYBER_K-1
+    addi t1, fp, STACK_ENC_V
+    add  a0, zero, s9
+    add  a1, zero, s10
     jal  x1, poly_getnoise_eta_1
-    add  a0, zero, a4
-    addi a2, a2, 1
+
+    add  a0, zero, s9
+    add  a3, zero, s8
+    addi s11, s11, 1
+    sw   s11, STACK_ENC_NONCE(fp)
+    jal  x1, poly_getnoise_eta_init
+
+    bn.wsrr   w16, 0x0 /* w16 = R | Q */
+    bn.shv.8S w0, w16 << 1 /* w0 = 2*R | 2*Q */
+    bn.wsrw   0x0, w0 /* MOD = 2*R | 2*Q */
+
+    add  a0, zero, s10
+    la   a1, twiddles_ntt
+    add  a2, zero, s10
+    jal  x1, ntt
+
+    bn.xor w31, w31, w31  /* w31 = 0 */
+    addi s10, s10, 2*KYBER_N
+    bn.wsrw   0x0, w16 /* MOD = R | Q */
+  .endr
+
+  addi t1, fp, STACK_ENC_V
+  add  a0, zero, s9
+  add  a1, zero, s10
+  add  a3, zero, s8
+  jal  x1, poly_getnoise_eta_1
 
   bn.wsrr   w16, 0x0 /* w16 = R | Q */
   bn.shv.8S w0, w16 << 1 /* w0 = 2*R | 2*Q */
   bn.wsrw   0x0, w0 /* MOD = 2*R | 2*Q */
-  /*** NTT sp ***/
-  li  a0, STACK_ENC_SP
-  add a0, fp, a0
-  la  a1, twiddles_ntt
-  add a2, zero, a0
-  .rept KYBER_K
-    jal x1, ntt
-  .endr
+
+  add  a0, zero, s10
+  la   a1, twiddles_ntt
+  add  a2, zero, s10
+  jal  x1, ntt
 
   /* After NTT, w6 is still R | Q and MOD is still 2*R | 2*Q */
   /** v = sp * pkpv **/
@@ -262,6 +291,12 @@ indcpa_enc:
     jal  x1, basemul_acc
   .endr
 
+  lw   a0, STACK_ENC_COINS_ADDR(fp)
+  addi a2, zero, 2*KYBER_K
+  sw   a2, STACK_ENC_NONCE(fp)
+  li   a3, STACK_ENC_NONCE
+  jal  x1, poly_getnoise_eta_init
+
   /* After basemul, w16 is still R | Q and MOD is still 2*R | 2*Q */
   /*** INTT v ***/
   li      a0, STACK_ENC_V
@@ -272,12 +307,8 @@ indcpa_enc:
   bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
 
   /*** CBD epp ***/
-  lw   a0, STACK_ENC_COINS_ADDR(fp)
   li   a1, STACK_ENC_EPP
   add  a1, fp, a1
-  addi a2, zero, 2*KYBER_K
-  sw   a2, STACK_ENC_NONCE(fp)
-  li   a3, STACK_ENC_NONCE
   li   t1, STACK_ENC_TMP
   add  t1, fp, t1
   jal  x1, poly_getnoise_eta_2
@@ -399,6 +430,14 @@ indcpa_enc:
 
   /* (End of public key rejection sampling) */
 
+  /* Prepare for initial `poly_getnoise_eta_2` call, performing the SHAKE
+     computation during `unpack_pk` */
+  lw   a0, STACK_ENC_COINS_ADDR(fp)
+  li   a3, STACK_ENC_NONCE
+  li   t0, KYBER_K
+  sw   t0, STACK_ENC_NONCE(fp)
+  jal  x1, poly_getnoise_eta_init
+
   /* After basemul, w16 is still R | Q and MOD is still 2*R | 2*Q */
   /*** INTT ***/
   li  a0, STACK_ENC_AT
@@ -410,31 +449,44 @@ indcpa_enc:
   .endr
   bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
 
-  /*** CBD ep ***/
-  lw  a0, STACK_ENC_COINS_ADDR(fp)
-  li  a1, STACK_ENC_EP
-  add a1, fp, a1
-  add a4, zero, a0
-  li  a5, STACK_ENC_TMP
-  li  a3, STACK_ENC_NONCE
-  li  a2, KYBER_K
-  LOOPI KYBER_K, 5
-    add  t1, fp, a5
-    sw   a2, STACK_ENC_NONCE(fp)
-    jal  x1, poly_getnoise_eta_2
-    add  a0, zero, a4
-    addi a2, a2, 1
+  /*** CBD ep + ADD ***/
+  li   a3, STACK_ENC_NONCE
+  lw   a4, STACK_ENC_COINS_ADDR(fp)
+  li   a5, STACK_ENC_EP
+  add  a5, fp, a5
+  li   a6, STACK_ENC_B
+  add  a6, fp, a6
+  li   s2, KYBER_K
 
-  /*** ADD ***/
-  /** b = b + ep **/
-  li  a0, STACK_ENC_B
-  add a0, fp, a0
-  li  a1, STACK_ENC_EP
-  add a1, fp, a1
-  add a2, zero, a0
-  .rept KYBER_K
-    jal x1, poly_add
+  .rept KYBER_K-1
+    addi t1, fp, STACK_ENC_TMP
+    add  a0, zero, a4
+    add  a1, zero, a5
+    jal  x1, poly_getnoise_eta_2
+
+    add  a0, zero, a4
+    addi s2, s2, 1
+    sw   s2, STACK_ENC_NONCE(fp)
+    jal  x1, poly_getnoise_eta_init
+
+    add  a0, zero, a6
+    add  a1, zero, a5
+    add  a2, zero, a6
+    jal  x1, poly_add
+
+    addi  a5, a5, 2*KYBER_N
+    addi  a6, a6, 2*KYBER_N
   .endr
+
+  addi t1, fp, STACK_ENC_TMP
+  add  a0, zero, a4
+  add  a1, zero, a5
+  jal  x1, poly_getnoise_eta_2
+
+  add  a0, zero, a6
+  add  a1, zero, a5
+  add  a2, zero, a6
+  jal  x1, poly_add
 
   /*** pack_ciphertext ***/
   li   a0, STACK_ENC_B

--- a/sw/otbn/crypto/mlkem/mlkem_keypair.s
+++ b/sw/otbn/crypto/mlkem/mlkem_keypair.s
@@ -210,10 +210,11 @@ indcpa_keypair:
   add  a1, fp, a1
   li   a3, STACK_NONCE
   li   a2, 0
-  LOOPI KYBER_K, 5
+  LOOPI KYBER_K, 6
     add  t1, fp, a5
     addi a0, fp, STACK_NOISESEED
     sw   a2, STACK_NONCE(fp)
+    jal  x1, poly_getnoise_eta_init
     jal  x1, poly_getnoise_eta_1
     addi a2, a2, 1
 
@@ -289,10 +290,11 @@ indcpa_keypair:
   add  a1, fp, a1
   li   a3, STACK_NONCE
   li   a2, KYBER_K
-  LOOPI KYBER_K, 5
+  LOOPI KYBER_K, 6
     add  t1, fp, a5
     addi a0, fp, STACK_NOISESEED
     sw   a2, STACK_NONCE(fp)
+    jal  x1, poly_getnoise_eta_init
     jal  x1, poly_getnoise_eta_1
     addi a2, a2, 1
 

--- a/sw/otbn/crypto/mlkem/poly.s
+++ b/sw/otbn/crypto/mlkem/poly.s
@@ -128,34 +128,23 @@ poly_tomsg:
   ret
 
 /*
- * Name:        poly_getnoise_eta1
+ * Name:        poly_getnoise_eta_init
  *
- * Description: Sample a polynomial deterministically from a seed and a nonce,
- *              with output polynomial close to centered binomial distribution
- *              with parameter KYBER_ETA1
- *
- * Arguments:   - poly *r: pointer to output polynomial
- *              - const uint8_t *seed: pointer to input seed (of length KYBER_SYMBYTES bytes)
- *              - uint8_t nonce: one-byte input nonce
+ * Description: Prepares for polynomial CBD sampling via either of
+ *              `poly_getnoise_eta_1` or `poly_getnoise_eta_2` given a seed and
+ *              a nonce by initializing a SHAKE256 operation.
  *
  * Flags: Clobbers FG0, has no meaning beyond the scope of this subroutine.
  *
- * @param[in]  w31: all-zero
  * @param[in]  x10: dptr_input, dmem pointer to input seed
  * @param[in]  x13: STACK_NONCE
- * @param[in]  x6: dmem_ptr to SHAKE256 results
- * @param[out] x11: dptr_output, dmem pointer to output polynomial
  *
- * clobbered registers: x4-x30, w0-w31
+ * clobbered registers: x5, x10
  * clobbered flag groups: None
  */
 
-.globl poly_getnoise_eta_1
-poly_getnoise_eta_1:
-  addi x2, x2, -8
-  sw   x11, 4(x2)
-  sw   x6, 0(x2)
-
+.globl poly_getnoise_eta_init
+poly_getnoise_eta_init:
   /* Initialize a SHAKE256 operation. */
   addi  x5, x0, 33
   slli  x5, x5, 5
@@ -168,6 +157,37 @@ poly_getnoise_eta_1:
   add     x10, x3, x13
   bn.lid  x0, 0(x10)
   bn.wsrw 0x9, w0
+
+  ret
+
+/*
+ * Name:        poly_getnoise_eta1
+ *
+ * Description: Sample a polynomial deterministically from a seed and a nonce,
+ *              with output polynomial close to centered binomial
+ *              distribution with parameter KYBER_ETA1; this function assumes
+ *              `poly_getnoise_eta_init` has been called first with the
+ *              appropriate seed and nonce
+ *
+ * Arguments:   - poly *r: pointer to output polynomial
+ *              - const uint8_t *seed: pointer to input seed (of length KYBER_SYMBYTES bytes)
+ *              - uint8_t nonce: one-byte input nonce
+ *
+ * Flags: Clobbers FG0, has no meaning beyond the scope of this subroutine.
+ *
+ * @param[in]  w31: all-zero
+ * @param[in]  x6: dmem_ptr to SHAKE256 results from `poly_getnoise_eta_init`
+ * @param[out] x11: dptr_output, dmem pointer to output polynomial
+ *
+ * clobbered registers: x4-x30, w0-w31
+ * clobbered flag groups: None
+ */
+
+.globl poly_getnoise_eta_1
+poly_getnoise_eta_1:
+  addi x2, x2, -8
+  sw   x11, 4(x2)
+  sw   x6, 0(x2)
 
   li x5, 8
   LOOPI LOOP_GETNOISE_1, 2
@@ -192,7 +212,9 @@ poly_getnoise_eta_1:
  *
  * Description: Sample a polynomial deterministically from a seed and a nonce,
  *              with output polynomial close to centered binomial distribution
- *              with parameter KYBER_ETA2
+ *              with parameter KYBER_ETA2; this function assumes
+ *              `poly_getnoise_eta_init` has been called first with the
+ *              appropriate seed and nonce
  *
  * Arguments:   - poly *r: pointer to output polynomial
  *              - const uint8_t *seed: pointer to input seed (of length KYBER_SYMBYTES bytes)
@@ -201,9 +223,7 @@ poly_getnoise_eta_1:
  * Flags: Clobbers FG0, has no meaning beyond the scope of this subroutine.
  *
  * @param[in]  w31: all-zero
- * @param[in]  x10: dptr_input, dmem pointer to input seed
- * @param[in]  x13: STACK_NONCE
- * @param[in]  x6: dmem_ptr to SHAKE256 results
+ * @param[in]  x6: dmem_ptr to SHAKE256 results from `poly_getnoise_eta_init`
  * @param[out] x11: dptr_output, dmem pointer to output polynomial
  *
  * clobbered registers: x4-x30, w0-w31
@@ -215,19 +235,6 @@ poly_getnoise_eta_2:
   addi x2, x2, -8
   sw   x11, 4(x2)
   sw   x6, 0(x2)
-
-  /* Initialize a SHAKE256 operation. */
-  addi  x5, x0, 33
-  slli  x5, x5, 5
-  addi  x5, x5, SHAKE256_CFG
-  csrrw x0, KECCAK_CFG_REG, x5
-
-  /* Send the message to the Keccak core. */
-  bn.lid  x0, 0(x10)
-  bn.wsrw 0x9, w0
-  add     x10, x3, x13
-  bn.lid  x0, 0(x10)
-  bn.wsrw 0x9, w0
 
   li x5, 8
   LOOPI 4, 2


### PR DESCRIPTION
This PR separates initializing SHAKE operations from the actual CBD sampling operation inside `poly_getnoise_eta_1`, interleaving operations in order to prevent `bn.wsrr` stalls when fetching from KMAC_DIGEST.

This provides a modest ~1.3% speedup to the encapsulation functest for ML-KEM-512. Note that for ML-KEM-512, `poly_getnoise_eta_1` reads KMAC_DIGEST 6 times, just barely requiring an extra SHAKE squeeze, which could be interleaved with part of `cbd3` in a future PR; this would improve the speedup from 1.3% to an estimated ~1.8%.