### PR TITLE
[mlkem] Use wide register for poly_gen_matrix nonce instead of stack

### DIFF
--- a/sw/otbn/crypto/mlkem/mlkem_encap.s
+++ b/sw/otbn/crypto/mlkem/mlkem_encap.s
@@ -34,6 +34,7 @@
   #define KYBER_CIPHERTEXT_WRS 24
   #define KYBER_GEN_MATRIX_NONCE 254
   #define KYBER_GEN_MATRIX_AT_NONCE -511
+  #define KYBER_GEN_MATRIX_AT_NONCE_NEG 511
   #define POLY -512
   #define K_POLYS -1024
   #define K_SQUARED_POLYS -2048
@@ -58,6 +59,7 @@
   #define KYBER_CIPHERTEXT_WRS 34
   #define KYBER_GEN_MATRIX_NONCE 253
   #define KYBER_GEN_MATRIX_AT_NONCE -767
+  #define KYBER_GEN_MATRIX_AT_NONCE_NEG 767
   #define POLY -512
   #define K_POLYS -1536
   #define K_SQUARED_POLYS -4608
@@ -82,6 +84,7 @@
   #define KYBER_CIPHERTEXT_WRS 49
   #define KYBER_GEN_MATRIX_NONCE 252
   #define KYBER_GEN_MATRIX_AT_NONCE -1023
+  #define KYBER_GEN_MATRIX_AT_NONCE_NEG 1023
   #define POLY -512
   #define K_POLYS -2048
   #define K_SQUARED_POLYS -8192
@@ -283,8 +286,8 @@ indcpa_enc:
   jal  x1, poly_getnoise_eta_2
 
   /* Prepare for the first call to poly_gen_matrix. */
-  li   a2, 0
   addi a0, fp, STACK_ENC_SEED
+  bn.xor w30, w30, w30
   jal  x1, poly_gen_matrix_init
 
   /** v = v + k + epp **/
@@ -304,7 +307,6 @@ indcpa_enc:
   /*** Matrix vector multiplication ***/
   li   a1, STACK_ENC_AT
   add  a1, fp, a1
-  li   a2, 0
 
   /* Run rejection sampling to generate the public key. */
 
@@ -317,7 +319,7 @@ indcpa_enc:
     /* Gen 1st mat poly */
     addi a0, fp, STACK_ENC_SEED
     jal  x1, poly_gen_matrix
-    addi a2, a2, 0x0100
+    bn.addi w30, w30, 0x0100
     jal  x1, poly_gen_matrix_init
 
     /* Mutliply this generated poly with sk */
@@ -332,7 +334,7 @@ indcpa_enc:
       /* Gen next mat poly */
       addi a0, fp, STACK_ENC_SEED
       jal  x1, poly_gen_matrix
-      addi a2, a2, 0x0100
+      bn.addi w30, w30, 0x0100
       jal  x1, poly_gen_matrix_init
 
       /* Mutliply this generated poly with sk */
@@ -346,8 +348,8 @@ indcpa_enc:
     /* Gen next mat poly */
     addi a0, fp, STACK_ENC_SEED
     jal  x1, poly_gen_matrix
-    addi a2, a2, 0x0100
-    addi a2, a2, KYBER_GEN_MATRIX_AT_NONCE
+    bn.addi w30, w30, 0x0100
+    bn.subi w30, w30, KYBER_GEN_MATRIX_AT_NONCE_NEG
     jal  x1, poly_gen_matrix_init
 
     /* Mutliply this generated poly with sk */
@@ -361,7 +363,7 @@ indcpa_enc:
   /* Gen 1st mat poly */
   addi a0, fp, STACK_ENC_SEED
   jal  x1, poly_gen_matrix
-  addi a2, a2, 0x0100
+  bn.addi w30, w30, 0x0100
   jal  x1, poly_gen_matrix_init
 
   /* Mutliply this generated poly with sk */
@@ -376,7 +378,7 @@ indcpa_enc:
     /* Gen next mat poly */
     addi a0, fp, STACK_ENC_SEED
     jal  x1, poly_gen_matrix
-    addi a2, a2, 0x0100
+    bn.addi w30, w30, 0x0100
     jal  x1, poly_gen_matrix_init
 
     /* Mutliply this generated poly with sk */

--- a/sw/otbn/crypto/mlkem/mlkem_keypair.s
+++ b/sw/otbn/crypto/mlkem/mlkem_keypair.s
@@ -240,13 +240,13 @@ indcpa_keypair:
   /*** Matrix-vector multiplication ***/
   li   a1, STACK_A
   add  a1, fp, a1
-  li   a2, 0
+  bn.xor w30, w30, w30
   .rept KYBER_K
     /* Gen 1st mat poly */
     addi a0, fp, STACK_PUBLICSEED
     jal  x1, poly_gen_matrix_init
     jal  x1, poly_gen_matrix
-    addi a2, a2, 1
+    bn.addi w30, w30, 1
 
     /* Mutliply this generated poly with sk */
     addi a1, a1, POLY /* point back to A[0][0] */
@@ -261,7 +261,7 @@ indcpa_keypair:
       addi a0, fp, STACK_PUBLICSEED
       jal  x1, poly_gen_matrix_init
       jal  x1, poly_gen_matrix
-      addi a2, a2, 1
+      bn.addi w30, w30, 1
 
       /* Mutliply this generated poly with sk */
       addi a1, a1, POLY /* points back to A[0][1] */
@@ -270,7 +270,7 @@ indcpa_keypair:
       jal  x1, basemul_acc
       addi a1, a1, POLY /* points back to A[0][1] */
     .endr
-    addi a2, a2, KYBER_GEN_MATRIX_NONCE
+    bn.addi w30, w30, KYBER_GEN_MATRIX_NONCE
   .endr
   bn.wsrw 0x0, w16 /* Restore MOD = R | Q */
 

--- a/sw/otbn/crypto/mlkem/poly_gen_matrix.s
+++ b/sw/otbn/crypto/mlkem/poly_gen_matrix.s
@@ -62,19 +62,13 @@
  * Flags: Clobbers FG0, has no meaning beyond the scope of this subroutine.
  *
  * @param[in]  a0: pointer to seed (KYBER_SYMBYTES = 32)
- * @param[in]  a2: i||j (2 bytes)
+ * @param[in]  w30: i||j (2 bytes)
  *
  * clobbered registers: a0, t0, w0
  */
 
 .globl poly_gen_matrix_init
 poly_gen_matrix_init:
-  /* Space for the nonce */
-  #define STACK_NONCE -64
-
-  /* Store nonce to memory */
-  sw a2, STACK_NONCE(fp)
-
   /* Initialize a SHAKE128 operation. */
   addi  t0, zero, 34
   slli  t0, t0, 5
@@ -84,9 +78,7 @@ poly_gen_matrix_init:
   /* Send the message to the Keccak core. */
   bn.lid x0, 0(a0)             /* a0 still contains the input buffer */
   bn.wsrw 0x9, w0              /* Write to KECCAK_MSG_REG */
-  addi a0, fp, STACK_NONCE     /* Set a0 to point to the nonce in memory */
-  bn.lid x0, 0(a0)
-  bn.wsrw 0x9, w0              /* Write to KECCAK_MSG_REG */
+  bn.wsrw 0x9, w30             /* Write to KECCAK_MSG_REG */
 
   ret
 
@@ -104,7 +96,6 @@ poly_gen_matrix_init:
  * Flags: Clobbers FG0, has no meaning beyond the scope of this subroutine.
  *
  * @param[in]  a0: pointer to seed (KYBER_SYMBYTES = 32)
- * @param[in]  a2: i||j (2 bytes)
  * @param[out] a1: dmem pointer to polynomial
  *
  * clobbered registers: a0-a5, t0-s4, w8, w14


### PR DESCRIPTION
This is a small change suggested by @jadephilipoom from the review of #47  (thanks for catching this!): 

Rather than pass the nonce to `poly_gen_matrix_init` in a GPR just to store it to the stack and read it into a wide register, this change makes it so that the nonce is tracked in a wide register. This tiny change saves 5 instructions per `poly_gen_matrix_init` call, which is increasingly helpful for larger key sizes.