### PR TITLE
[otbn] Add a script to profile OTBN programs.

### DIFF
--- a/hw/ip/otbn/util/otbn_profile.py
+++ b/hw/ip/otbn/util/otbn_profile.py
@@ -1,0 +1,58 @@
+#! /usr/bin/env python3
+
+import argparse
+import re
+
+HEADING_START = "Function cycle counts"
+HEADING_LINES = 4
+
+FUNC_PAT = re.compile(r'([a-z0-9_]+) +\[([0-9]+), ([0-9]+)\]')
+
+
+def parse_function_stats(statsfile):
+    heading_index = None
+    counts = {}
+    for line in statsfile.readlines():
+        line = line.strip()
+        if heading_index is None:
+            if line == HEADING_START:
+                heading_index = 1
+            continue
+        if heading_index < HEADING_LINES:
+            assert re.match(FUNC_PAT, line) is None
+            heading_index += 1
+            continue
+        # if we get here we're past the heading, get the stats
+        m = re.match(FUNC_PAT, line)
+        if m is None:
+            if line != "":
+                raise ValueError(f'Malformatted line: {line}')
+            # if the line is empty, we finished the stats, break from loop
+            break
+        name = m.group(1)
+        instr = m.group(2)
+        stall = m.group(3)
+        counts[name] = [int(instr), int(stall)]
+    if heading_index is None:
+        raise ValueError(f'Heading line does not appear in input: {HEADING_START}')
+    return counts
+
+
+def pretty_print_profile(stats):
+    cycles_per_function = {k: sum(v) for k, v in stats.items()}
+    total_cycles = sum(cycles_per_function.values())
+    for name, cycles in cycles_per_function.items():
+        pct = cycles * 100 / total_cycles
+        print(f'{pct:.02f}%\t{cycles}\t{name}')
+    print('Total cycles:', total_cycles)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'stats', type=argparse.FileType('r'),
+        help=('Statistics as dumped by the OTBN simulator.'))
+    args = parser.parse_args()
+
+    stats = parse_function_stats(args.stats)
+    pretty_print_profile(stats)


### PR DESCRIPTION
Tells you how many cycles are spent in each function, which is useful for optimizations. For example:

```
$ hw/ip/otbn/dv/otbnsim/standalone.py --dump-stats div_small_test.stats bazel-bin/sw/otbn/crypto/tests/div_small_test.elf
$ hw/ip/otbn/util/otbn_profile.py div_small_test.stats 
61.85%	9216	cond_sub_shifted
22.34%	3328	bignum_rshift1
15.63%	2329	div
0.12%	18	    _imem_start
0.06%	9	    bignum_lshift256
Total cycles: 14900
```

CC @phamhnh so you know this exists in case it's useful to you :slightly_smiling_face: