### PR TITLE
[otbn, rtl] Reset the partial write register value after a write to msg FIFO

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -457,6 +457,8 @@ class KmacMsgWSR(WSR):
                                  {len(value_bytes)} bytes to App FIFO")
                 self._pending_write_to_app_intf = False
                 self._kmac._app_intf_writing = True
+                # Reset paritial write value after successful write
+                self._partial_ispr._value = 32
 
     def pending_write_pw(self) -> bool:
         if self._kmac._app_intf_fifo_flush and not self._pending_write_to_app_intf:

--- a/hw/ip/otbn/dv/rig/rig/gens/app_req.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/app_req.py
@@ -249,6 +249,7 @@ class KmacAppReqInsn(SnippetGen):
             self._fill_wsrw_mode = FillWsrwMode.MSG
             prog_wsrw_msg = self.fill_bn_wsrw(model)
             remaining_bytes -= self._pw_size
+            self._pw_size = 32
             current_write_count += 1
             insn_list.append(prog_wsrw_msg)
 

--- a/hw/ip/otbn/dv/smoke_pqc/smoke_test.s
+++ b/hw/ip/otbn/dv/smoke_pqc/smoke_test.s
@@ -123,7 +123,7 @@ csrrw x0, mod0, x23
 csrrs x23, mod5, x0
 
 bn.wsrr w1, 0x0 /* MOD 82a 4ea*/
-li x23, 0x000004ea
+li x23, 0x000008ea
 csrrw x0, kmac_cfg, x23
 li x23, 0x0000001a
 csrrw x0, kmac_partial_write, x23
@@ -131,12 +131,13 @@ bn.wsrw 0x9, w1 /* MSG */
 li x23, 0x0000000d
 csrrw x0, kmac_partial_write, x23
 bn.wsrw 0x9, w1 /* MSG */
+bn.wsrw 0x9, w1 /* MSG */
 bn.wsrr w2, 0xa /* DIGEST */
 bn.wsrr w2, 0xa /* DIGEST */
 bn.wsrr w2, 0xa /* DIGEST */
 bn.wsrr w2, 0xa /* DIGEST */
 bn.wsrr w3, 0xa /* DIGEST */
-li x23, 0x800004ea /* STOP CFG 0x8000040a */
+li x23, 0x800008ea /* STOP CFG 0x8000040a */
 csrrw x0, kmac_cfg, x23
 
 li x23, 0x53769ada

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -535,6 +535,9 @@ module otbn_alu_bignum
   logic                     kmac_pw_wr_en;
   logic [1:0]               kmac_pw_intg_err;
   logic [5:0]               kmac_pw_mask;
+
+  // Nets from other blocks needed to reset the partial write
+  logic                     kmac_msg_fifo_wvalid;
   logic                     kmac_msg_valid_q;
   logic                     kmac_sent_last;
 
@@ -566,7 +569,7 @@ module otbn_alu_bignum
   assign kmac_pw_wr_en = (ispr_init_i | kmac_pw_ispr_wr_en) & (~kmac_msg_valid_q | kmac_sent_last);
 
   always_ff @(posedge clk_i) begin
-    if (kmac_pw_wr_en | kmac_new_cfg_q) begin
+    if (kmac_pw_wr_en | kmac_new_cfg_q | kmac_msg_fifo_wvalid) begin
       kmac_pw_intg_q  <= kmac_pw_intg_d;
     end
   end
@@ -577,12 +580,16 @@ module otbn_alu_bignum
         kmac_pw_no_intg_d = 32'b0;
         kmac_pw_intg_d    = kmac_pw_intg_calc;
       end
-      ispr_base_wr_en_i[0]: begin
+      ispr_base_wr_en_i[0] & !kmac_msg_pending_write_o: begin
         kmac_pw_no_intg_d = ispr_base_wdata_i;
         kmac_pw_intg_d    = kmac_pw_intg_calc;
       end
       kmac_new_cfg_q: begin
         kmac_pw_no_intg_d = 32'h20; // Set to full length at the start of cfg
+        kmac_pw_intg_d    = kmac_pw_intg_calc;
+      end
+      kmac_msg_fifo_wvalid: begin // Reset the partial word at each write
+        kmac_pw_no_intg_d = 32'h20;
         kmac_pw_intg_d    = kmac_pw_intg_calc;
       end
       default: begin
@@ -804,7 +811,6 @@ module otbn_alu_bignum
 
   logic                           kmac_msg_err_clr;
   logic                           kmac_msg_err_clr_q;
-  logic                           kmac_msg_fifo_wvalid;
   logic                           kmac_msg_fifo_wready;
   logic [WLEN-1:0]                kmac_msg_fifo_wdata;
   logic [WLEN-1:0]                kmac_msg_fifo_wdata_mask;


### PR DESCRIPTION
This behavior matches the documentation of the partial-write WSR. Previously, subsequent writes after setting the partial-write register would also be truncated.

Also fixed up multiple valid cases in the partial write unique case combinational block.

This includes the HW changes in addition to SW from #50