### PR TITLE
[kmac, rtl] Fixes to invalid sideload key error state handling

### DIFF
--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -452,13 +452,6 @@ module kmac_app
 
           service_rejected_error_set = 1'b 1;
 
-        end else if ((AppCfg[app_id].Mode == AppKMAC) &&
-          !keymgr_key_i.valid) begin
-            st_d = StKeyMgrErrKeyNotValid;
-
-            // As mux_sel is not set to SelApp, app_data_ready is still 0.
-            // This logic won't accept the requests from the selected App.
-
         end else if ((AppCfg[app_id].Mode == AppConfigDynamic)) begin
 
           st_d = StAppDynamicCfg;
@@ -1179,9 +1172,9 @@ module kmac_app
 
   // Error Reporting ==========================================================
   always_comb begin
-    priority casez ({fsm_err.valid, mux_err.valid, digest_packer_error})
-      3'b ?1: error_o = mux_err;
-      3'b 10: error_o = fsm_err;
+    priority casez ({digest_packer_error, fsm_err.valid, mux_err.valid})
+      3'b??1: error_o = mux_err;
+      3'b?10: error_o = fsm_err;
       3'b100: error_o = '{valid: 1'b0, code: ErrAppIntfPacker, info: '0};
       default: error_o = '{valid: 1'b0, code: ErrNone, info: '0};
     endcase

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -236,7 +236,10 @@ module kmac_app
   // Digest packer for OTBN app intf
   logic [255:0] digest_word_share_0, digest_word_share_1;
   logic [255:0] packed_digest_word_share_0, packed_digest_word_share_1;
-  logic packed_digest_word_valid, packed_digest_word_valid_share_0, packed_digest_word_valid_share_1;
+  logic [255:0] digest_word_share_valid_0, digest_word_share_valid_1;
+  logic app_rsp_err;
+  logic packed_digest_word_valid;
+  logic packed_digest_word_valid_share_0, packed_digest_word_valid_share_1;
   logic digest_packer_ready, digest_packer_ready_share_0, digest_packer_ready_share_1;
   logic digest_packer_error, digest_packer_error_share_0, digest_packer_error_share_1;
   logic req_packed_digest_word;
@@ -278,8 +281,9 @@ module kmac_app
   assign digest_word_idx_d = digest_word_idx_q;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) digest_word_idx_q <= 3'h0;
-    else if ((app_i[AppConfigDynamic].valid && set_appid) || reset_digest_word) digest_word_idx_q <= 3'h0;
-    else if (next_digest_word) digest_word_idx_q <= digest_word_idx_d + 3'h1;
+    else if ((app_i[AppConfigDynamic].valid && set_appid) || reset_digest_word) begin
+      digest_word_idx_q <= 3'h0;
+    end else if (next_digest_word) digest_word_idx_q <= digest_word_idx_d + 3'h1;
   end
 
   // Processing return data.
@@ -287,16 +291,21 @@ module kmac_app
   // clear digest right after done to not leak info to other interface
   // OTBN mode operates different with 256-bit digest being padded out of packer FIFO
   always_comb begin
+    app_rsp_err = error_i | fsm_digest_done_q | sparse_fsm_error_o | service_rejected_error;
+    digest_word_share_valid_0 = (app_rsp_err | !packed_digest_word_valid) ?
+                                  256'b0 : packed_digest_word_share_0;
+    digest_word_share_valid_1 = (app_rsp_err | !packed_digest_word_valid) ?
+                                  256'b0 : packed_digest_word_share_1;
     for (int unsigned i = 0 ; i < NumAppIntf; i++) begin
       if (i == app_id) begin
         app_o[i] = '{
           ready:         app_data_ready | fsm_data_ready,
-          done:          (AppCfg[app_id].Mode == AppConfigDynamic) ? otbn_app_intf_done
-                                                      : (app_digest_done | fsm_digest_done_q),
-          digest_share0: (AppCfg[app_id].Mode == AppConfigDynamic) ? {128'h0, packed_digest_word_share_0}
-                                                      : app_digest[0],
-          digest_share1: (AppCfg[app_id].Mode == AppConfigDynamic) ? {128'h0, packed_digest_word_share_1}
-                                                      : app_digest[1],
+          done:          (AppCfg[app_id].Mode == AppConfigDynamic) ?
+                            otbn_app_intf_done : (app_digest_done | fsm_digest_done_q),
+          digest_share0: (AppCfg[app_id].Mode == AppConfigDynamic) ?
+                            {128'h0, digest_word_share_valid_0} : app_digest[0],
+          digest_share1: (AppCfg[app_id].Mode == AppConfigDynamic) ?
+                            {128'h0, digest_word_share_valid_1} : app_digest[1],
           // if fsm asserts done, should be an error case.
           error:         error_i | fsm_digest_done_q | sparse_fsm_error_o
                          | service_rejected_error


### PR DESCRIPTION
I found that `kmac-mubi-err`, `kmac-sideload-invalid`, and `kmac-key-error` DV tests were failing. The bugs were introduced in #13 but only the App Intf tests were run at the time. A full regression run has been completed to diagnose these remaining failing test cases.

### kmac-mubi-err
The test was failing due to an assertion that digest share0 and share1 were not 0 when there was an error in the digest response. This was caused by always assigning the output ports to the output value of the `prim_packer`, but the packer always has the output be it's internal contents, regardless of if the full 256-bit word is available. Now data is assigned on the same cycle as response done and is 0 otherwise, or if there is a response error.

### kmac-sideload-invalid & kmac-key-error
Both tests were failing due to improper handling of invalid key sideload errors in the App FSM. First the `error_o` case statement had its bit concatenation in the wrong order, meaning FSM errors were not being reported/handled appropriately.

Additionally, there was a bad state transition in StAppCfg that essentially killed the handling of an invalid key. Invalid keys are already being handled, and acknowledging them in this state kills the ability to recover from errors. The FSM attempts to recover and start the SHA3 module, but the start signal is is only high for half a clock cycle, meaning the SHA3 internal FSM never transitions from its idle state, leaving KMAC in a stuck state.