### PR TITLE
[verible, rtl] Fixed linting warnings in KMAC and OTBN for CI

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_intf.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_intf.sv
@@ -75,8 +75,8 @@ interface kmac_app_intf (input clk, input rst_n);
 
   assign kmac_data_req = (if_mode == dv_utils_pkg::Host) ?
                          {req_data_if.valid, hold, next, req_data_if.h_data} : 'z;
-  assign {req_data_if.valid, hold_tmp, next_tmp, req_data_if.h_data} = (if_mode == dv_utils_pkg::Device) ?
-                                                   kmac_data_req : 'z;
+  assign {req_data_if.valid, hold_tmp, next_tmp, req_data_if.h_data} =
+      (if_mode == dv_utils_pkg::Device) ? kmac_data_req : 'z;
 
   assign {req_data_if.ready, rsp_done, rsp_digest_share0, rsp_digest_share1, rsp_error} =
          (if_mode == dv_utils_pkg::Host) ? kmac_data_rsp : 'z;
@@ -145,6 +145,9 @@ interface kmac_app_intf (input clk, input rst_n);
             end
           end
         end
+      end
+      default: begin
+        // This case shouldn't be reachable
       end
     endcase
   end

--- a/hw/ip/kmac/dv/env/kmac_if.sv
+++ b/hw/ip/kmac/dv/env/kmac_if.sv
@@ -20,16 +20,20 @@ interface kmac_if(input clk_i, input rst_ni);
   `ASSERT(KmacMaskingO_A, `EN_MASKING == en_masking_o)
 
   `ASSERT(AppKeymgrErrOutputZeros_A, app_rsp[kmac_app_agent_pkg::AppKeymgr].error |->
-          app_rsp[kmac_app_agent_pkg::AppKeymgr].digest_share0 == 0 && app_rsp[kmac_app_agent_pkg::AppKeymgr].digest_share1 == 0)
+          app_rsp[kmac_app_agent_pkg::AppKeymgr].digest_share0 == 0 &&
+          app_rsp[kmac_app_agent_pkg::AppKeymgr].digest_share1 == 0)
 
   `ASSERT(AppLcErrOutputZeros_A, app_rsp[kmac_app_agent_pkg::AppLc].error |->
-          app_rsp[kmac_app_agent_pkg::AppLc].digest_share0 == 0 && app_rsp[kmac_app_agent_pkg::AppLc].digest_share1 == 0)
+          app_rsp[kmac_app_agent_pkg::AppLc].digest_share0 == 0 &&
+          app_rsp[kmac_app_agent_pkg::AppLc].digest_share1 == 0)
 
   `ASSERT(AppRomErrOutputZeros_A, app_rsp[kmac_app_agent_pkg::AppRom].error |->
-          app_rsp[kmac_app_agent_pkg::AppRom].digest_share0 == 0 && app_rsp[kmac_app_agent_pkg::AppRom].digest_share1 == 0)
+          app_rsp[kmac_app_agent_pkg::AppRom].digest_share0 == 0 &&
+          app_rsp[kmac_app_agent_pkg::AppRom].digest_share1 == 0)
 
   `ASSERT(AppOtbnErrOutputZeros_A, app_rsp[kmac_app_agent_pkg::AppOtbn].error |->
-          app_rsp[kmac_app_agent_pkg::AppOtbn].digest_share0 == 0 && app_rsp[kmac_app_agent_pkg::AppOtbn].digest_share1 == 0)
+          app_rsp[kmac_app_agent_pkg::AppOtbn].digest_share0 == 0 &&
+          app_rsp[kmac_app_agent_pkg::AppOtbn].digest_share1 == 0)
 
   // Assertions to check if hold is high outside of OTBN mode
   `ASSERT(AppKeymgrHoldNever_A, !app_req[kmac_app_agent_pkg::AppKeymgr].hold)

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -33,7 +33,8 @@ module kmac
   // Accept SW message when idle and before receiving a START command. Useful for SCA only.
   parameter bit SecIdleAcceptSwMsg          = 1'b0,
   parameter int unsigned NumAppIntf         = 4,
-  parameter app_config_t AppCfg[NumAppIntf] = '{AppCfgKeyMgr, AppCfgLcCtrl, AppCfgRomCtrl, AppCfgOTBN},
+  parameter app_config_t AppCfg[NumAppIntf] = '{AppCfgKeyMgr, AppCfgLcCtrl,
+                                                AppCfgRomCtrl, AppCfgOTBN},
 
   parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault,
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -17,7 +17,8 @@ module kmac_app
   localparam int          Share              = (EnMasking) ? 2 : 1, // derived parameter
   parameter  bit          SecIdleAcceptSwMsg = 1'b0,
   parameter  int unsigned NumAppIntf         = 4,
-  parameter  app_config_t AppCfg[NumAppIntf] = '{AppCfgKeyMgr, AppCfgLcCtrl, AppCfgRomCtrl, AppCfgOTBN}
+  parameter  app_config_t AppCfg[NumAppIntf] = '{AppCfgKeyMgr, AppCfgLcCtrl,
+                                                 AppCfgRomCtrl, AppCfgOTBN}
 ) (
   input clk_i,
   input rst_ni,
@@ -530,9 +531,12 @@ module kmac_app
       end
 
       StAppWait: begin
-        if (prim_mubi_pkg::mubi4_test_true_strict(absorbed_i) || prim_mubi_pkg::mubi4_test_true_strict(squeezing_i)) begin
+        if (prim_mubi_pkg::mubi4_test_true_strict(absorbed_i) ||
+            prim_mubi_pkg::mubi4_test_true_strict(squeezing_i))
+        begin
           digest_valid = 1'b 1;
-          if (app_i[app_id].hold == 1'b0) begin // hold always 1'b0 for non-otbn modes maintaining normal behavior
+          // hold always 1'b0 for non-otbn modes maintaining normal behavior
+          if (app_i[app_id].hold == 1'b0) begin
             // Send digest to KeyMgr and complete the op
             st_d = StIdle;
             cmd_o = CmdDone;
@@ -886,14 +890,17 @@ module kmac_app
 
   // Set the final word size for SHAKE 128/256 modes given rate
   // SHA3 mode has fixed 256/512 bit sizes for OTBN
-  assign digest_word_mask = (dynamic_keccak_strength_q == sha3_pkg::L128 && digest_word_idx_q == 3'h5)  ? { {192{1'b0}}, {64{1'b1}} } :
-                            ((dynamic_keccak_strength_q == sha3_pkg::L256 && digest_word_idx_q == 3'h4) ? { {192{1'b0}}, {64{1'b1}} } : {256{1'b1}});
+  assign digest_word_mask = (dynamic_keccak_strength_q == sha3_pkg::L128 &&
+                            digest_word_idx_q == 3'h5) ? { {192{1'b0}}, {64{1'b1}} } :
+                            ((dynamic_keccak_strength_q == sha3_pkg::L256 &&
+                            digest_word_idx_q == 3'h4) ? { {192{1'b0}}, {64{1'b1}} } :
+                            {256{1'b1}});
 
   assign req_packed_digest_word = app_active_o && (AppCfg[app_id].Mode == AppConfigDynamic);
 
   // Set the digest shares based on masked mode and word index into keccak state
   generate
-  if (Share == 2) begin
+  if (Share == 2) begin : gen_masked_digest_word_assign
     always_comb begin
       unique case (digest_word_idx_q)
         3'h0: begin
@@ -926,7 +933,7 @@ module kmac_app
         end
       endcase
     end
-  end else begin
+  end else begin : gen_unmasked_digest_word_assign
     always_comb begin
       digest_word_share_1 = 256'h0;
       unique case (digest_word_idx_q)
@@ -968,10 +975,16 @@ module kmac_app
   end
 
   // Logic for digest share packer FIFOs in order to pack digest into 256-bit words
-  assign pack_digest_word = ((prim_mubi_pkg::mubi4_test_true_strict(squeezing_i) && !squeezing_q) || shift_and_pack_digest) && ~clr_appid && (AppCfg[app_id].Mode == AppConfigDynamic);
-  assign otbn_app_intf_done = packed_digest_word_valid && ~clr_appid && ((st == StAppWait) || (st == StAppShiftDigest) || (st == StAppManualRun));
+  // we are either squeezing from the input or shifting from FSM
+  assign pack_digest_word = ((prim_mubi_pkg::mubi4_test_true_strict(squeezing_i) && !squeezing_q)
+                            || shift_and_pack_digest) && ~clr_appid
+                            && (AppCfg[app_id].Mode == AppConfigDynamic);
+  // Assert done for digest when packer has valid word and we are in valid state to push
+  assign otbn_app_intf_done = packed_digest_word_valid && ~clr_appid && ((st == StAppWait) ||
+                              (st == StAppShiftDigest) || (st == StAppManualRun));
   assign digest_packer_ready = digest_packer_ready_share_0 & digest_packer_ready_share_1;
-  assign packed_digest_word_valid = packed_digest_word_valid_share_0 & packed_digest_word_valid_share_1;
+  assign packed_digest_word_valid = packed_digest_word_valid_share_0 &&
+                                    packed_digest_word_valid_share_1;
   assign digest_packer_error = digest_packer_error_share_0 | digest_packer_error_share_1;
 
   prim_packer #(
@@ -1016,7 +1029,8 @@ module kmac_app
 
   // Keccak state --> KeyMgr
 
-  assign sha3_digest_done = (prim_mubi_pkg::mubi4_test_true_strict(absorbed_i) || prim_mubi_pkg::mubi4_test_true_strict(squeezing_i)) && digest_valid;
+  assign sha3_digest_done = (prim_mubi_pkg::mubi4_test_true_strict(absorbed_i) ||
+                            prim_mubi_pkg::mubi4_test_true_strict(squeezing_i)) && digest_valid;
   always_comb begin
     app_digest_done = 1'b 0;
     app_digest = '{default:'0};

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -283,6 +283,9 @@ interface otbn_trace_if
                                                 u_otbn_alu_bignum.mod_intg_q[i_word*39+:32];
         assign ispr_read_data[IsprMod][i_word*32+:32] = u_otbn_alu_bignum.mod_intg_q[i_word*39+:32];
         assign ispr_write_data[IsprAcc][i_word*32+:32] = u_otbn_mac_bignum.acc_intg_d[i_word*39+:32];
+        assign ispr_write_data[IsprKmacMsg][i_word*32+:32] = 32'b0;
+        assign ispr_read_data[IsprKmacMsg][i_word*32+:32] = 32'b0;
+        assign ispr_write_data[IsprAccH][i_word*32+:32] = 32'b0;
       end
     end
   endgenerate
@@ -297,30 +300,54 @@ interface otbn_trace_if
       // KMAC MSG
       assign ispr_read[IsprKmacMsg] =
         (any_ispr_read & (ispr_addr == IsprKmacMsg));
-
       assign ispr_write[IsprKmacMsg] = u_otbn_alu_bignum.gen_pqc_wsr.kmac_msg_wr_en & ~ispr_init;
-
       // KMAC CFG
       assign ispr_read[IsprKmacCfg] =
         (any_ispr_read & (ispr_addr == IsprKmacCfg));
-
       assign ispr_read_data[IsprKmacCfg]  = {224'b0, u_otbn_alu_bignum.gen_pqc_wsr.kmac_cfg_intg_q[31:0]};
       assign ispr_write[IsprKmacCfg]      = u_otbn_alu_bignum.gen_pqc_wsr.kmac_cfg_wr_en & ~ispr_init;
       assign ispr_write_data[IsprKmacCfg] = {224'b0, u_otbn_alu_bignum.gen_pqc_wsr.kmac_cfg_intg_d[31:0]};
-
       // KMAC PARTIAL WRITE
       assign ispr_read[IsprKmacPartialW] =
         (any_ispr_read & (ispr_addr == IsprKmacPartialW));
-
       assign ispr_read_data[IsprKmacPartialW]   = {224'b0, u_otbn_alu_bignum.gen_pqc_wsr.kmac_pw_intg_q[31:0]};
       assign ispr_write[IsprKmacPartialW]       = u_otbn_alu_bignum.gen_pqc_wsr.kmac_pw_wr_en & ~ispr_init;
       assign ispr_write_data[IsprKmacPartialW]  = {224'b0, u_otbn_alu_bignum.gen_pqc_wsr.kmac_pw_intg_d[31:0]};
-
+      // ACCH
       assign ispr_write[IsprAccH]     = u_otbn_mac_bignum.gen_acch_wr_en.acch_en & ~ispr_init;
       assign ispr_read[IsprAccH]      = (any_ispr_read & (ispr_addr == IsprAccH)) | mac_bignum_en;
       assign ispr_read_data[IsprAccH] =
           (any_ispr_read & (ispr_addr == IsprAccH)) ? u_otbn_mac_bignum.gen_acch_reg.acch_no_intg_q :
                                                       u_otbn_mac_bignum.gen_acch_blanker.acch_blanked;
+    end else begin : gen_ispr_read_write_blank
+      // Need to drive unused signals for verilator linting
+      // KMAC MSG
+      assign ispr_read[IsprKmacMsg]  = 1'b0;
+      assign ispr_write[IsprKmacMsg] = 1'b0;
+      // KMAC CFG
+      assign ispr_read[IsprKmacCfg]       = 1'b0;
+      assign ispr_read_data[IsprKmacCfg]  = 256'b0;
+      assign ispr_write[IsprKmacCfg]      = 1'b0;
+      assign ispr_write_data[IsprKmacCfg] = 256'b0;
+      // KMAC PARTIAL WRITE
+      assign ispr_read[IsprKmacPartialW]        = 1'b0;
+      assign ispr_read_data[IsprKmacPartialW]   = 256'b0;
+      assign ispr_write[IsprKmacPartialW]       = 1'b0;
+      assign ispr_write_data[IsprKmacPartialW]  = 256'b0;
+      // KMAC STATUS
+      assign ispr_read[IsprKmacStatus]       = 1'b0;
+      assign ispr_read_data[IsprKmacStatus]  = 256'b0;
+      assign ispr_write[IsprKmacStatus]      = 1'b0;
+      assign ispr_write_data[IsprKmacStatus] = 256'b0;
+      // KMAC DIGEST
+      assign ispr_read[IsprKmacDigest]       = 1'b0;
+      assign ispr_read_data[IsprKmacDigest]  = 256'b0;
+      assign ispr_write[IsprKmacDigest]      = 1'b0;
+      assign ispr_write_data[IsprKmacDigest] = 256'b0;
+      // ACCH
+      assign ispr_write[IsprAccH]     = 1'b0;
+      assign ispr_read[IsprAccH]      = 1'b0;
+      assign ispr_read_data[IsprAccH] = 256'b0;
     end
   endgenerate
 

--- a/hw/ip/otbn/rtl/bn_vec_core/buffer_bit.sv
+++ b/hw/ip/otbn/rtl/bn_vec_core/buffer_bit.sv
@@ -31,12 +31,12 @@ module buffer_bit
   genvar i;
 
   generate
-    for (i = 0; i < 16; i++) begin
+    for (i = 0; i < 16; i++) begin : gen_a_b_buffed_init
       assign A_buffed[i*17 +: 16] = A[i*16 +: 16];
       assign B_buffed[i*17 +: 16] = B[i*16 +: 16];
     end
 
-    for (i = 1; i < 16; i += 1) begin
+    for (i = 1; i < 16; i += 1) begin : gen_a_b_buffed_res
       assign A_buffed[i*17 - 1] = (word_mode == VecType_h16) ? (((i*16) % 16) == 0 ? cin : 1'b0) :
                                   (word_mode == VecType_s32) ? (((i*16) % 32) == 0 ? cin : 1'b0) :
                                   (word_mode == VecType_d64) ? (((i*16) % 64) == 0 ? cin : 1'b0) :
@@ -51,7 +51,7 @@ module buffer_bit
   assign R_buffed = A_buffed + B_buffed + {271'b0, cin};
 
   generate
-    for(i = 0; i < 16; i++) begin
+    for(i = 0; i < 16; i++) begin : gen_result
       assign res[i*16 +: 16] = R_buffed[i*17 +: 16];
       assign cout[i] = R_buffed[i*17 + 16];
     end

--- a/hw/ip/otbn/rtl/bn_vec_core/unified_mul.sv
+++ b/hw/ip/otbn/rtl/bn_vec_core/unified_mul.sv
@@ -27,14 +27,13 @@ module unified_mul #(
 );
 
   localparam int NHALF = WLEN / HLEN;  // 16
-  localparam int NSING = WLEN / SLEN;  // 8
   localparam int NDOUB = WLEN / DLEN;  // 4
 
   // -------------------------------------------------------------------
   // Input and intermediate arrays
   // -------------------------------------------------------------------
-  logic [HLEN-1:0] A16 [0:NHALF-1];
-  logic [HLEN-1:0] B16 [0:NHALF-1];
+  logic [HLEN-1:0] A16 [NHALF];
+  logic [HLEN-1:0] B16 [NHALF];
 
   logic [4*SLEN-1:0] A32;
   logic [4*SLEN-1:0] B32;
@@ -42,12 +41,12 @@ module unified_mul #(
   logic [WLEN-1:0] A_composed;
   logic [WLEN-1:0] B_composed;
 
-  logic [2*HLEN-1:0] products [0:NHALF-1];
-  logic [2*SLEN-1:0] partial32 [0:NDOUB-1];
+  logic [2*HLEN-1:0] products [NHALF];
+  logic [2*SLEN-1:0] partial32 [NDOUB];
 
-  localparam MODE_64 = 2'b00;
-  localparam MODE_32 = 2'b11;
-  localparam MODE_16 = 2'b10;
+  localparam logic [1:0] MODE_64 = 2'b00;
+  localparam logic [1:0] MODE_32 = 2'b11;
+  localparam logic [1:0] MODE_16 = 2'b10;
 
   logic [63:0] scalar64_A;
   logic [63:0] scalar64_B;
@@ -81,7 +80,8 @@ module unified_mul #(
               B_composed[i*HLEN +: HLEN] = (lane_mode == 1'b0) ? B[HLEN*i +: HLEN] : scalar16;
             end else begin
               A_composed[(i+1)*HLEN +: HLEN] = A[(i+1)*HLEN +: HLEN];
-              B_composed[(i+1)*HLEN +: HLEN] = (lane_mode == 1'b0) ? B[(i+1)*HLEN +: HLEN] : scalar16;
+              B_composed[(i+1)*HLEN +: HLEN] = (lane_mode == 1'b0) ?
+                                               B[(i+1)*HLEN +: HLEN] : scalar16;
             end
           end
         end else begin
@@ -251,6 +251,9 @@ module unified_mul #(
           2'd1: result[ 64 +: 128] = result_64;
           2'd2: result[128 +: 128] = result_64;
           2'd3: result[192 +: 128] = result_64;
+          default: begin
+            // Not possible to reach state
+          end
         endcase
       end
       MODE_32: begin

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -146,6 +146,14 @@ module otbn_alu_bignum
   // Tie unused ports to '0
   generate
     if (!OtbnPQCEn) begin : gen_unused_outputs
+      // Tie off unused inputs
+      logic unused_bits;
+      assign unused_bits = ^{operation_i.trn_type, operation_i.vector_sel, operation_i.vector_type,
+                             alu_predec_bignum_i.trn_type, alu_predec_bignum_i.vector_sel,
+                             alu_predec_bignum_i.vector_type, ispr_acch_intg_i,
+                             sec_wipe_kmac_regs_urnd_i, kmac_app_rsp_i};
+
+      // Drive outputs to 0
       assign ispr_acch_wr_data_intg_o = '0;
       assign ispr_acch_wr_en_o        = '0;
       assign kmac_msg_write_ready_o   = '0;

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -152,6 +152,8 @@ module otbn_alu_bignum
       assign kmac_msg_pending_write_o = '0;
       assign kmac_digest_valid_o      = '0;
       assign kmac_app_req_o           = '0;
+    end else begin : gen_unused_pqc_bits
+      logic unused_pqc_bits;
     end
   endgenerate
 
@@ -461,8 +463,8 @@ module otbn_alu_bignum
   //////////
   // KMAC //
   //////////
-  generate
-    if (OtbnPQCEn) begin : gen_pqc_wsr
+generate
+  if (OtbnPQCEn) begin : gen_pqc_wsr
   // CFG
   logic [BaseIntgWidth-1:0] kmac_cfg_intg_q;
   logic [31:0]              kmac_cfg_no_intg_d;
@@ -772,7 +774,8 @@ module otbn_alu_bignum
   end
 
   assign kmac_digest_valid_o = kmac_digest_valid_q;
-  assign kmac_digest_rd_next = kmac_digest_valid_q && ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest];
+  assign kmac_digest_rd_next = kmac_digest_valid_q &&
+                               ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest];
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -828,6 +831,8 @@ module otbn_alu_bignum
   logic [7:0] packer_rdata_mask;
   logic [3:0] packer_rdata_mask_cnt;
 
+  logic kmac_app_active;
+  logic kmac_app_last;
   logic kmac_msg_active_q;
   logic kmac_cfg_active_q;
   logic kmac_write_cfg_to_app;
@@ -836,7 +841,6 @@ module otbn_alu_bignum
   logic kmac_idle_q;
   logic kmac_cfg_done;
   logic kmac_app_cfg_sent;
-  logic kmac_msg_fifo_pending;
 
   // Oversized and undersized msg handling
   logic kmac_msg_req_err;
@@ -998,7 +1002,7 @@ module otbn_alu_bignum
       packer_rdata_mask[i] = |kmac_msg_fifo_rdata_mask[i*8 +: 8];
     end
     foreach (packer_rdata_mask[i]) begin
-      packer_rdata_mask_cnt += packer_rdata_mask[i];
+      packer_rdata_mask_cnt += {3'b0, packer_rdata_mask[i]};
     end
   end
 
@@ -1006,9 +1010,8 @@ module otbn_alu_bignum
   assign kmac_msg_wr_stall = (kmac_msg_write & (~kmac_msg_fifo_wready));
 
   // When reading the return digest the message has already been sent and any remainder is cleared
-  assign kmac_msg_fifo_clr = kmac_sent_last
-                             && (ispr_addr_i == IsprKmacDigest)
-                             && !kmac_msg_pending_write_o;
+  assign kmac_msg_fifo_clr = kmac_sent_last && (ispr_addr_i == IsprKmacDigest) &&
+                             !kmac_msg_pending_write_o;
 
   // Prim packer is used to send full words until the final word in msg request
   prim_packer #(
@@ -1058,35 +1061,41 @@ module otbn_alu_bignum
   );
 
   // Ensure that the read mask is at least the size of the cfg before asserting last
-  assign packer_ctr_last       = (packer_rdata_mask_cnt >= kmac_cfg_msg_len_bytes);
+  assign packer_ctr_last       = (packer_rdata_mask_cnt >= {1'b0, kmac_cfg_msg_len_bytes});
 
   // If it is time for the final word and there is a partial word we need to flush it out
-  assign kmac_msg_fifo_flush   = (kmac_msg_last && (kmac_cfg_msg_len_bytes != 3'h0)
-                                 && ~kmac_msg_fifo_rvalid);
+  assign kmac_msg_fifo_flush   = (kmac_msg_last && (kmac_cfg_msg_len_bytes != 3'h0) &&
+                                 ~kmac_msg_fifo_rvalid);
 
-  assign kmac_write_cfg_to_app =  kmac_cfg_active_q
-                                  && (~kmac_msg_active_q | ~kmac_app_cfg_sent)
-                                  && ~kmac_idle_q;
+  assign kmac_write_cfg_to_app =  kmac_cfg_active_q && (~kmac_msg_active_q | ~kmac_app_cfg_sent) &&
+                                  ~kmac_idle_q;
 
   // fifo write iface
-  assign kmac_msg_fifo_wdata      = kmac_msg_no_intg_q;
-  assign kmac_msg_fifo_wvalid     = kmac_cfg_active_q && kmac_msg_valid_q && kmac_msg_fifo_wready
-                                    && ~kmac_msg_fifo_flush && ~kmac_sent_last && (~kmac_msg_last);
+  assign kmac_msg_fifo_wdata  = kmac_msg_no_intg_q;
+  assign kmac_msg_fifo_wvalid = kmac_cfg_active_q && kmac_msg_valid_q && kmac_msg_fifo_wready &&
+                                ~kmac_msg_fifo_flush && ~kmac_sent_last && (~kmac_msg_last);
 
   assign kmac_msg_write_ready_o   = kmac_msg_fifo_wready;
   assign kmac_msg_pending_write_o = kmac_msg_valid_q && ~kmac_sent_last;
 
   // fifo read iface
-  assign kmac_msg_fifo_rready = (kmac_app_rsp_i.ready & ~kmac_write_cfg_to_app)
-                                 | (kmac_sent_last | kmac_msg_err_clr_q);
-  assign kmac_msg_last        = (kmac_cfg_msg_len_bytes == 3'h0) ?
-                                (kmac_msg_ctr >= kmac_cfg_msg_len_words - 1) && kmac_msg_fifo_rvalid :
-                                ((kmac_msg_ctr >= kmac_cfg_msg_len_words) && packer_ctr_last);
+  assign kmac_msg_fifo_rready = (kmac_app_rsp_i.ready & ~kmac_write_cfg_to_app) |
+                                (kmac_sent_last | kmac_msg_err_clr_q);
+
+  assign kmac_msg_last = (kmac_cfg_msg_len_bytes == 3'h0) ?
+                        (kmac_msg_ctr >= kmac_cfg_msg_len_words - 1) && kmac_msg_fifo_rvalid :
+                        ((kmac_msg_ctr >= kmac_cfg_msg_len_words) && packer_ctr_last);
+
+  // Compute the assignment for kmac_app_req_o.hold
+  assign kmac_app_active = kmac_cfg_active_q & ~kmac_new_cfg_q & ~kmac_cfg_done;
+
+  // Compute the assignment for kmac_app_req_o.last
+  assign kmac_app_last = kmac_inject_last_err | (kmac_msg_fifo_rvalid & kmac_msg_last);
 
   // When there is an undersized message we artificially inject a last valid to finish the message
   assign kmac_app_req_o.valid = (kmac_write_cfg_to_app || kmac_inject_last_err) ?
-                                1'b1 : kmac_msg_fifo_rvalid && ~kmac_new_cfg_q
-                                       && ~kmac_sent_last && ~kmac_msg_err_clr_q;
+                                1'b1 : kmac_msg_fifo_rvalid && ~kmac_new_cfg_q &&
+                                      ~kmac_sent_last && ~kmac_msg_err_clr_q;
 
   // The first word contains the cfg otherwise send the body
   assign kmac_app_req_o.data  = kmac_write_cfg_to_app ?
@@ -1095,11 +1104,11 @@ module otbn_alu_bignum
 
   // The strb will always be 8'hFF except for the CFG and last word
   assign kmac_app_req_o.strb  = kmac_write_cfg_to_app ?
-                                8'h01 : kmac_app_req_o.last ?
+                                8'h01 : kmac_app_last ?
                                 kmac_last_msg_strb : {(kmac_pkg::MsgStrbW){1'b1}};
 
   // When there is an undersized message we artifically inject a last signal to finish the message
-  assign kmac_app_req_o.last  = kmac_inject_last_err | (kmac_msg_fifo_rvalid & kmac_msg_last);
+  assign kmac_app_req_o.last  = kmac_app_last;
 
   // If we request an additional digest send a next to KMAC
   assign kmac_app_req_o.next  = kmac_digest_valid_o
@@ -1107,25 +1116,25 @@ module otbn_alu_bignum
                                 & kmac_next_sha;
 
   // Hold will remain active for duration of transaction unless an internal error occurs
-  assign kmac_app_req_o.hold  = kmac_cfg_active_q & ~kmac_new_cfg_q & ~kmac_cfg_done;
+  assign kmac_app_req_o.hold  = kmac_app_active;
 
   // check for incomplete msg with pending digest
   // Latch for last in current transaction
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      kmac_pending_last = 1'b0;
-      kmac_sent_last = 1'b0;
+      kmac_pending_last <= 1'b0;
+      kmac_sent_last <= 1'b0;
     end else begin
       // Either we observed a valid last or we artificially created a last
       if ((kmac_msg_fifo_rvalid & kmac_msg_last) | kmac_inject_last_err) begin
-        kmac_pending_last = 1'b1; // Prepared to send the final word
+        kmac_pending_last <= 1'b1; // Prepared to send the final word
         if (kmac_app_rsp_i.ready) begin
-          kmac_sent_last = 1'b1;
+          kmac_sent_last <= 1'b1;
         end
       end else if (kmac_cfg_wr_en) begin
         // Clear any last flags after a new cfg is written
-        kmac_pending_last = 1'b0;
-        kmac_sent_last = 1'b0;
+        kmac_pending_last <= 1'b0;
+        kmac_sent_last <= 1'b0;
       end
     end
   end
@@ -1136,9 +1145,9 @@ module otbn_alu_bignum
   // The FIFO should not be in a flush cycle
   always_comb begin
     kmac_msg_req_err = 1'b0;
-    if (ispr_addr_i == IsprKmacDigest && kmac_app_req_o.hold) begin
+    if (ispr_addr_i == IsprKmacDigest && kmac_app_active) begin
       kmac_msg_req_err = (!kmac_msg_pending_write_o && !kmac_msg_fifo_rvalid
-                         && !kmac_msg_fifo_flush && !kmac_msg_fifo_wvalid);
+                        && !kmac_msg_fifo_flush && !kmac_msg_fifo_wvalid);
     end
   end
 
@@ -1197,20 +1206,21 @@ module otbn_alu_bignum
 
   // The cfg reads 0 when it is a full word which means the mask is 8 so we must skip evaluation
   // at these sizes, otherwise check if mask is greater than the cfg
-  assign not_full_word          = ~(packer_rdata_mask_cnt == 4'h8 & kmac_cfg_msg_len_bytes == 4'h0);
-  assign packer_oversized_last  = not_full_word & (packer_rdata_mask_cnt > kmac_cfg_msg_len_bytes);
+  assign not_full_word         = ~(packer_rdata_mask_cnt == 4'h8 & kmac_cfg_msg_len_bytes == 3'h0);
+  assign packer_oversized_last =
+      not_full_word & (packer_rdata_mask_cnt > {1'b0, kmac_cfg_msg_len_bytes});
 
   assign last_word_oversized    = kmac_msg_last & packer_oversized_last;
   // Read or write to/from FIFO that occurs after last
   assign rw_after_last          = kmac_sent_last & (kmac_msg_fifo_rvalid | kmac_msg_valid_q);
   // There is still a pending write to the FIFO while last is being asserted after flush
-  assign write_during_last      = kmac_app_req_o.last & kmac_msg_valid_q;
+  assign write_during_last      = kmac_app_last & kmac_msg_valid_q;
   // Injecting an artificial last may impact the write_during_last flag so we check that the
   // message isn't undersized before raising this flag
   assign kmac_oversized_req_err = (rw_after_last | write_during_last)
                                   & ~kmac_undersized_req_err_latch | last_word_oversized;
-    end
-  endgenerate
+  end
+endgenerate
 
   /////////
   // ACC //
@@ -1291,25 +1301,30 @@ module otbn_alu_bignum
   assign ispr_rdata_no_intg_mux_in[IsprAcc]         = 0;
   generate
     if (OtbnPQCEn) begin : gen_ispr_no_intg_mux_pqc
-      assign ispr_rdata_no_intg_mux_in[IsprKmacMsg]     = 0;
-      assign ispr_rdata_no_intg_mux_in[IsprKmacCfg]     = {224'b0, gen_pqc_wsr.kmac_cfg_intg_q[31:0]};
-      assign ispr_rdata_no_intg_mux_in[IsprKmacStatus]  = {224'b0, gen_pqc_wsr.kmac_status_intg_q[31:0]};
-      assign ispr_rdata_no_intg_mux_in[IsprKmacDigest]  = 0;
-      assign ispr_rdata_no_intg_mux_in[IsprAccH]        = 0;
+      assign ispr_rdata_no_intg_mux_in[IsprKmacMsg] = 0;
+
+      assign ispr_rdata_no_intg_mux_in[IsprKmacCfg] =
+          {224'b0, gen_pqc_wsr.kmac_cfg_intg_q[31:0]};
+
+      assign ispr_rdata_no_intg_mux_in[IsprKmacStatus] =
+          {224'b0, gen_pqc_wsr.kmac_status_intg_q[31:0]};
+
+      assign ispr_rdata_no_intg_mux_in[IsprKmacDigest] = 0;
+      assign ispr_rdata_no_intg_mux_in[IsprAccH]       = 0;
     end
   endgenerate
 
   assign ispr_rdata_no_intg_mux_in[IsprRnd]    = rnd_data_i;
   assign ispr_rdata_no_intg_mux_in[IsprUrnd]   = urnd_data_i;
   assign ispr_rdata_no_intg_mux_in[IsprFlags]  = {{(WLEN - (NFlagGroups * FlagsWidth)){1'b0}},
-                                                 flags_flattened};
+                                                flags_flattened};
   // SEC_CM: KEY.SIDELOAD
   assign ispr_rdata_no_intg_mux_in[IsprKeyS0L] = sideload_key_shares_i[0][255:0];
   assign ispr_rdata_no_intg_mux_in[IsprKeyS0H] = {{(WLEN - (SideloadKeyWidth - 256)){1'b0}},
-                                                  sideload_key_shares_i[0][SideloadKeyWidth-1:256]};
+                                                 sideload_key_shares_i[0][SideloadKeyWidth-1:256]};
   assign ispr_rdata_no_intg_mux_in[IsprKeyS1L] = sideload_key_shares_i[1][255:0];
   assign ispr_rdata_no_intg_mux_in[IsprKeyS1H] = {{(WLEN - (SideloadKeyWidth - 256)){1'b0}},
-                                                  sideload_key_shares_i[1][SideloadKeyWidth-1:256]};
+                                                 sideload_key_shares_i[1][SideloadKeyWidth-1:256]};
 
   logic [WLEN-1:0]    ispr_rdata_no_intg;
   logic [ExtWLEN-1:0] ispr_rdata_intg_calc;
@@ -1340,8 +1355,10 @@ module otbn_alu_bignum
 
   generate
     if (OtbnPQCEn) begin : gen_ispr_intg_mux_pqc
-      assign ispr_rdata_intg_mux_in[gen_ispr_ids_pqc.IsprKmacMsgIntg]    = gen_pqc_wsr.kmac_msg_intg_q;
-      assign ispr_rdata_intg_mux_in[gen_ispr_ids_pqc.IsprKmacDigestIntg] = gen_pqc_wsr.kmac_digest_intg_q;
+      assign ispr_rdata_intg_mux_in[gen_ispr_ids_pqc.IsprKmacMsgIntg]    =
+          gen_pqc_wsr.kmac_msg_intg_q;
+      assign ispr_rdata_intg_mux_in[gen_ispr_ids_pqc.IsprKmacDigestIntg] =
+          gen_pqc_wsr.kmac_digest_intg_q;
       assign ispr_rdata_intg_mux_in[gen_ispr_ids_pqc.IsprAccHIntg]       = ispr_acch_intg_i;
     end
   endgenerate
@@ -1351,9 +1368,12 @@ module otbn_alu_bignum
 
   generate
     if (OtbnPQCEn) begin : gen_ispr_intg_mux_sel_pqc
-      assign ispr_rdata_intg_mux_sel[gen_ispr_ids_pqc.IsprKmacMsgIntg]     = ispr_predec_bignum_i.ispr_rd_en[IsprKmacMsg];
-      assign ispr_rdata_intg_mux_sel[gen_ispr_ids_pqc.IsprKmacDigestIntg]  = ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest];
-      assign ispr_rdata_intg_mux_sel[gen_ispr_ids_pqc.IsprAccHIntg]        = ispr_predec_bignum_i.ispr_rd_en[IsprAccH];
+      assign ispr_rdata_intg_mux_sel[gen_ispr_ids_pqc.IsprKmacMsgIntg]    =
+          ispr_predec_bignum_i.ispr_rd_en[IsprKmacMsg];
+      assign ispr_rdata_intg_mux_sel[gen_ispr_ids_pqc.IsprKmacDigestIntg] =
+          ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest];
+      assign ispr_rdata_intg_mux_sel[gen_ispr_ids_pqc.IsprAccHIntg]       =
+          ispr_predec_bignum_i.ispr_rd_en[IsprAccH];
     end
   endgenerate
 
@@ -1451,44 +1471,47 @@ module otbn_alu_bignum
     .out_o(shifter_operand_b_blanked)
   );
 
-  generate
-    if (OtbnPQCEn) begin : gen_shifter_pqc
-      logic [WLEN-1:0]   shifter_bignum_in_upper, shifter_bignum_in_lower, shifter_bignum_in_lower_reverse;
-      logic [WLEN*2-1:0] shifter_bignum_in;
-      logic [WLEN*2-1:0] shifter_bignum_out;
-      logic [WLEN-1:0]   shifter_bignum_out_lower_reverse;
-      logic [WLEN-1:0]   shifter_bignum_res;
-      logic [15:0]       shifter_vec_in [16:0];
-      logic [15:0]       shifter_vec_in_orig [15:0];
-      logic [15:0]       shifter_vec_in_reverse [15:0];
-      logic [15:0]       shifter_vec_out [15:0];
-      logic [31:0]       shifter_vec_tmp [15:0];
-      logic [31:0]       shifter_vec_tmp_shifted [15:0];
-      logic [15:0]       shifter_vec_out_reverse [15:0];
-      logic [WLEN-1:0]   shifter_vec_res;
-      logic              shifter_selvector_i;
+generate
+  if (OtbnPQCEn) begin : gen_shifter_pqc
+    logic [WLEN-1:0]   shifter_bignum_in_upper, shifter_bignum_in_lower;
+    logic [WLEN-1:0]   shifter_bignum_in_lower_reverse;
+    logic [WLEN*2-1:0] shifter_bignum_in;
+    logic [WLEN*2-1:0] shifter_bignum_out;
+    logic [WLEN-1:0]   shifter_bignum_out_lower_reverse;
+    logic [WLEN-1:0]   shifter_bignum_res;
+    logic [15:0]       shifter_vec_in [17];
+    logic [15:0]       shifter_vec_in_orig [16];
+    logic [15:0]       shifter_vec_in_reverse [16];
+    logic [15:0]       shifter_vec_out [16];
+    logic [31:0]       shifter_vec_tmp [16];
+    logic [31:0]       shifter_vec_tmp_shifted [16];
+    logic [15:0]       shifter_vec_out_reverse [16];
+    logic [WLEN-1:0]   shifter_vec_res;
+    logic              shifter_selvector_i;
 
-      // BIGNUM SHIFTER
-      // Operand A is only used for BN.RSHI, otherwise the upper input is 0. For all instructions other
-      // than BN.RHSI alu_predec_bignum_i.shifter_a_en will be 0, resulting in 0 for the upper input.
-      assign shifter_bignum_in_upper = shifter_operand_a_blanked;
-      assign shifter_bignum_in_lower = shifter_operand_b_blanked;
+    // BIGNUM SHIFTER
+    // Operand A is only used for BN.RSHI, otherwise the upper input is 0. For all insns other
+    // than BN.RHSI alu_predec_bignum_i.shifter_a_en will be 0, resulting in 0 for the upper input.
+    assign shifter_bignum_in_upper = shifter_operand_a_blanked;
+    assign shifter_bignum_in_lower = shifter_operand_b_blanked;
 
-      for (genvar i = 0; i < WLEN; i++) begin : g_shifter_bignum_in_lower_reverse
-        assign shifter_bignum_in_lower_reverse[i] = shifter_bignum_in_lower[WLEN-i-1];
-      end
+    for (genvar i = 0; i < WLEN; i++) begin : g_shifter_bignum_in_lower_reverse
+      assign shifter_bignum_in_lower_reverse[i] = shifter_bignum_in_lower[WLEN-i-1];
+    end
 
-      assign shifter_bignum_in = {shifter_bignum_in_upper,
-          alu_predec_bignum_i.shift_right ? shifter_bignum_in_lower : shifter_bignum_in_lower_reverse};
+    assign shifter_bignum_in = {shifter_bignum_in_upper,
+        alu_predec_bignum_i.shift_right ? shifter_bignum_in_lower
+                                        : shifter_bignum_in_lower_reverse};
 
-      assign shifter_bignum_out = shifter_bignum_in >> alu_predec_bignum_i.shift_amt;
+    assign shifter_bignum_out = shifter_bignum_in >> alu_predec_bignum_i.shift_amt;
 
       for (genvar i = 0; i < WLEN; i++) begin : g_shifter_bignum_out_lower_reverse
         assign shifter_bignum_out_lower_reverse[i] = shifter_bignum_out[WLEN-i-1];
       end
 
       assign shifter_bignum_res =
-          alu_predec_bignum_i.shift_right ? shifter_bignum_out[WLEN-1:0] : shifter_bignum_out_lower_reverse;
+          alu_predec_bignum_i.shift_right ? shifter_bignum_out[WLEN-1:0]
+                                          : shifter_bignum_out_lower_reverse;
 
       // VECTOR SHIFTER
       assign shifter_selvector_i = operation_i.vector_type[0];
@@ -1509,7 +1532,8 @@ module otbn_alu_bignum
         assign shifter_vec_tmp_shifted[i] = shifter_vec_tmp[i] >> alu_predec_bignum_i.shift_amt;
         assign shifter_vec_out[i] =
             (shifter_selvector_i | (i % 2 == 1)) ?
-                (shifter_vec_in[i] >> alu_predec_bignum_i.shift_amt) : shifter_vec_tmp_shifted[i][15:0];
+            (shifter_vec_in[i] >> alu_predec_bignum_i.shift_amt) :
+            shifter_vec_tmp_shifted[i][15:0];
 
         for (genvar j=0; j<WLEN/16; ++j) begin : g_shifter_vec_reverse_output
           assign shifter_vec_out_reverse[i][j] =
@@ -1521,7 +1545,8 @@ module otbn_alu_bignum
       end
 
       // SHIFTER RESULT
-      assign shifter_res = (operation_i.op == otbn_pkg::AluOpBignumShv) ? shifter_vec_res : shifter_bignum_res;
+      assign shifter_res = (operation_i.op == otbn_pkg::AluOpBignumShv) ? shifter_vec_res
+                                                                        : shifter_bignum_res;
 
       // Only the lower WLEN bits of the shift result are returned.
       assign unused_shifter_out_upper = shifter_bignum_out[WLEN*2-1:WLEN];
@@ -1565,15 +1590,15 @@ module otbn_alu_bignum
   ///////////////
   generate
     if (OtbnPQCEn) begin : gen_trn_pqc
-      logic [WLEN/16-1:0] trn_op0_16h [15:0];
-      logic [WLEN/8-1:0]  trn_op0_8s  [7:0];
-      logic [WLEN/4-1:0]  trn_op0_4d  [3:0];
-      logic [WLEN/2-1:0]  trn_op0_2q  [1:0];
+      logic [WLEN/16-1:0] trn_op0_16h [16];
+      logic [WLEN/8-1:0]  trn_op0_8s  [8];
+      logic [WLEN/4-1:0]  trn_op0_4d  [4];
+      logic [WLEN/2-1:0]  trn_op0_2q  [2];
 
-      logic [WLEN/16-1:0] trn_op1_16h [15:0];
-      logic [WLEN/8-1:0]  trn_op1_8s  [7:0];
-      logic [WLEN/4-1:0]  trn_op1_4d  [3:0];
-      logic [WLEN/2-1:0]  trn_op1_2q  [1:0];
+      logic [WLEN/16-1:0] trn_op1_16h [16];
+      logic [WLEN/8-1:0]  trn_op1_8s  [8];
+      logic [WLEN/4-1:0]  trn_op1_4d  [4];
+      logic [WLEN/2-1:0]  trn_op1_2q  [2];
 
       logic [WLEN-1:0]    trn_res;
 
@@ -1686,8 +1711,9 @@ module otbn_alu_bignum
       logic [WLEN-1:0]  adder_y_op_a, adder_y_op_b;
 
       vec_type_e mode;
-      assign mode = operation_i.vector_sel ? (operation_i.vector_type[0] == 1'b0 ? VecType_s32 : VecType_h16) :
-                                            VecType_v256;
+      assign mode = operation_i.vector_sel ?
+                    (operation_i.vector_type[0] == 1'b0 ? VecType_s32 : VecType_h16) :
+                    VecType_v256;
 
       // SEC_CM: DATA_REG_SW.SCA
       prim_blanker #(.Width(WLEN)) u_adder_x_op_a_blanked (
@@ -2299,19 +2325,20 @@ module otbn_alu_bignum
 
           // For pseudo-mod operations the result depends upon initial a + b / a - b result that is
           // computed in X. Operation to add/subtract mod (X + mod / X - mod) is computed in Y.
-          // Subtraction is computed using in the X & Y adders as a - b == a + ~b + 1. Note that for
-          // a - b the top bit of the result will be set if a - b >= 0 and otherwise clear.
+          // Subtraction is computed using in the X & Y adders as a - b == a + ~b + 1. Note that
+          // for a - b the top bit of the result will be set if a - b >= 0 and otherwise clear.
 
           // BN.ADDM - X = a + b, Y = X - mod, subtract mod if a + b >= mod
           // * If X generates carry a + b > mod (as mod is 256-bit) - Select Y result
-          // * If Y generates carry X - mod == (a + b) - mod >= 0 hence a + b >= mod, note this is only
-          //   valid if X does not generate carry - Select Y result
+          // * If Y generates carry X - mod == (a + b) - mod >= 0 hence a + b >= mod, note this is
+          // only valid if X does not generate carry - Select Y result
           // * If neither happen a + b < mod - Select X result
           AluOpBignumAddm: begin
-            // `adder_y_res` is always used: either as condition in the following `if` statement or, if
-            // the `if` statement short-circuits, in the body of the `if` statement.
+            // `adder_y_res` is always used: either as condition in the following `if` statement
+            // or, if the `if` statement short-circuits, in the body of the `if` statement.
             adder_y_res_used = 1'b1;
-            if (gen_adder_pqc.adder_x_carry_out[15] || gen_adder_y_res_pqc.adder_y_carry_out[15]) begin
+            if (gen_adder_pqc.adder_x_carry_out[15] || gen_adder_y_res_pqc.adder_y_carry_out[15])
+            begin
               operation_result_o = adder_y_res;
             end else begin
               operation_result_o = gen_adder_pqc.adder_x_res;
@@ -2323,18 +2350,20 @@ module otbn_alu_bignum
           end
 
           AluOpBignumAddvm: begin
-            // `adder_y_res` is always used: either as condition in the following `if` statement or, if
-            // the `if` statement short-circuits, in the body of the `if` statement.
+            // `adder_y_res` is always used: either as condition in the following `if` statement
+            // or, if the `if` statement short-circuits, in the body of the `if` statement.
             adder_y_res_used = 1'b1;
 
             for (int i = 0; i < 16; i += 2) begin
               operation_result_o[i*16 +: 16] = ((operation_i.vector_type[0]) ?
-                  (gen_adder_pqc.adder_x_carry_out[i] || gen_adder_y_res_pqc.adder_y_carry_out[i]) :
-                  (gen_adder_pqc.adder_x_carry_out[i + 1] || gen_adder_y_res_pqc.adder_y_carry_out[i + 1])) ?
-                      adder_y_res[i*16 +: 16] : gen_adder_pqc.adder_x_res[i*16 +: 16];
+                (gen_adder_pqc.adder_x_carry_out[i] || gen_adder_y_res_pqc.adder_y_carry_out[i]) :
+                (gen_adder_pqc.adder_x_carry_out[i + 1]
+                || gen_adder_y_res_pqc.adder_y_carry_out[i + 1])) ?
+                adder_y_res[i*16 +: 16] : gen_adder_pqc.adder_x_res[i*16 +: 16];
               operation_result_o[(i + 1)* 16 +: 16] =
-                (gen_adder_pqc.adder_x_carry_out[i + 1] || gen_adder_y_res_pqc.adder_y_carry_out[i + 1]) ?
-                    adder_y_res[(i + 1)*16 +: 16] : gen_adder_pqc.adder_x_res[(i + 1)*16 +: 16];
+                (gen_adder_pqc.adder_x_carry_out[i + 1]
+                || gen_adder_y_res_pqc.adder_y_carry_out[i + 1]) ?
+                adder_y_res[(i + 1)*16 +: 16] : gen_adder_pqc.adder_x_res[(i + 1)*16 +: 16];
             end
           end
 
@@ -2401,17 +2430,17 @@ module otbn_alu_bignum
 
           // For pseudo-mod operations the result depends upon initial a + b / a - b result that is
           // computed in X. Operation to add/subtract mod (X + mod / X - mod) is computed in Y.
-          // Subtraction is computed using in the X & Y adders as a - b == a + ~b + 1. Note that for
-          // a - b the top bit of the result will be set if a - b >= 0 and otherwise clear.
+          // Subtraction is computed using in the X & Y adders as a - b == a + ~b + 1. Note that
+          // for a - b the top bit of the result will be set if a - b >= 0 and otherwise clear.
 
           // BN.ADDM - X = a + b, Y = X - mod, subtract mod if a + b >= mod
           // * If X generates carry a + b > mod (as mod is 256-bit) - Select Y result
-          // * If Y generates carry X - mod == (a + b) - mod >= 0 hence a + b >= mod, note this is only
-          //   valid if X does not generate carry - Select Y result
+          // * If Y generates carry X - mod == (a + b) - mod >= 0 hence a + b >= mod, note this is
+          // only valid if X does not generate carry - Select Y result
           // * If neither happen a + b < mod - Select X result
           AluOpBignumAddm: begin
-            // `adder_y_res` is always used: either as condition in the following `if` statement or, if
-            // the `if` statement short-circuits, in the body of the `if` statement.
+            // `adder_y_res` is always used: either as condition in the following `if` statement
+            // or, if the `if` statement short-circuits, in the body of the `if` statement.
             adder_y_res_used = 1'b1;
             if (gen_adder.adder_x_res[WLEN+1] || adder_y_res[WLEN+1]) begin
               operation_result_o = adder_y_res[WLEN:1];
@@ -2455,6 +2484,17 @@ module otbn_alu_bignum
   logic unused_operation_commit;
   assign unused_operation_commit = operation_commit_i;
 
+  // Tie off unused bits from pqc signals
+  generate
+    if (OtbnPQCEn) begin : gen_tie_pqc_bits
+      assign gen_unused_pqc_bits.unused_pqc_bits =
+          ^{gen_pqc_wsr.ispr_kmac_cfg_bignum_wdata_intg_blanked[311:39],
+            gen_pqc_wsr.ispr_kmac_pw_bignum_wdata_intg_blanked[311:39],
+            gen_pqc_wsr.kmac_pw_intg_err,
+            gen_pqc_wsr.unmasked_digest_share[383:256]};
+    end
+  endgenerate
+
   // Determine if `mod_intg_q` is used.  The control signals are only valid if `operation_i.op` is
   // not none. If `shift_mod_sel` is low, `mod_intg_q` flows into `adder_y_op_b` and from there
   // into `adder_y_res`.  In this case, `mod_intg_q` is used iff  `adder_y_res` flows into
@@ -2468,24 +2508,27 @@ module otbn_alu_bignum
   generate
     if (OtbnPQCEn) begin : gen_reg_intg_err_pqc
       logic kmac_used;
-      assign kmac_used = operation_valid_i & (operation_i.op != AluOpBignumNone) & ( |(ispr_predec_bignum_i.ispr_rd_en[IsprKmacMsg])    |
-                                                                                    |(ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest]) |
-                                                                                    |(ispr_predec_bignum_i.ispr_rd_en[IsprKmacCfg])    |
-                                                                                    |(ispr_predec_bignum_i.ispr_rd_en[IsprKmacStatus]) );
+      assign kmac_used = operation_valid_i & (operation_i.op != AluOpBignumNone) &
+                         ( |(ispr_predec_bignum_i.ispr_rd_en[IsprKmacMsg])    |
+                           |(ispr_predec_bignum_i.ispr_rd_en[IsprKmacDigest]) |
+                           |(ispr_predec_bignum_i.ispr_rd_en[IsprKmacCfg])    |
+                           |(ispr_predec_bignum_i.ispr_rd_en[IsprKmacStatus]) );
       `ASSERT_KNOWN(KmacUsed_A, kmac_used)
 
-      // Raise a register integrity violation error iff `mod_intg_q` is used and (at least partially)
-      // invalid.
-      assign reg_intg_violation_err_o = (mod_used & |(mod_intg_err)) | (kmac_used & ( |(gen_pqc_wsr.kmac_msg_intg_err)    |
-                                                                                      |(gen_pqc_wsr.kmac_cfg_intg_err)    |
-                                                                                      |(gen_pqc_wsr.kmac_status_intg_err) |
-                                                                                      |(gen_pqc_wsr.kmac_digest_intg_err) ));
+      // Raise a register integrity violation error iff `mod_intg_q` is used
+      // and (at least partially) invalid.
+      assign reg_intg_violation_err_o = (mod_used & |(mod_intg_err)) |
+                                        (kmac_used & ( |(gen_pqc_wsr.kmac_msg_intg_err)    |
+                                                       |(gen_pqc_wsr.kmac_cfg_intg_err)    |
+                                                       |(gen_pqc_wsr.kmac_status_intg_err) |
+                                                       |(gen_pqc_wsr.kmac_digest_intg_err) ));
 
       // Detect and signal unexpected secure wipe signals.
-      assign sec_wipe_err_o = (sec_wipe_kmac_regs_urnd_i | sec_wipe_mod_urnd_i) & ~sec_wipe_running_i;
+      assign sec_wipe_err_o = (sec_wipe_kmac_regs_urnd_i | sec_wipe_mod_urnd_i)
+                              & ~sec_wipe_running_i;
     end else begin : gen_reg_intg_err
-      // Raise a register integrity violation error iff `mod_intg_q` is used and (at least partially)
-      // invalid.
+      // Raise a register integrity violation error iff `mod_intg_q` is used
+      // and (at least partially)invalid.
       assign reg_intg_violation_err_o = mod_used & |(mod_intg_err);
 
       // Detect and signal unexpected secure wipe signals.
@@ -2504,11 +2547,15 @@ module otbn_alu_bignum
   generate
     if (OtbnPQCEn) begin : gen_blanking_x_res_pqc
       `ASSERT(BlankingBignumAluXOp_A,
-              !expected_adder_x_en |-> {gen_adder_pqc.adder_x_op_a_blanked, gen_adder_pqc.adder_x_op_b_blanked,gen_adder_pqc.adder_x_res} == '0,
+              !expected_adder_x_en |->
+              {gen_adder_pqc.adder_x_op_a_blanked, gen_adder_pqc.adder_x_op_b_blanked,
+               gen_adder_pqc.adder_x_res} == '0,
               clk_i, !rst_ni || alu_predec_error_o || !operation_commit_i)
     end else begin : gen_blanking_x_res
       `ASSERT(BlankingBignumAluXOp_A,
-              !expected_adder_x_en |-> {gen_adder.adder_x_op_a_blanked, gen_adder.adder_x_op_b_blanked,gen_adder.adder_x_res} == '0,
+              !expected_adder_x_en |->
+              {gen_adder.adder_x_op_a_blanked, gen_adder.adder_x_op_b_blanked,
+               gen_adder.adder_x_res} == '0,
               clk_i, !rst_ni || alu_predec_error_o || !operation_commit_i)
     end
   endgenerate
@@ -2527,12 +2574,14 @@ module otbn_alu_bignum
   generate
     if (OtbnPQCEn) begin : gen_blanking_alu_y_res_pqc
       `ASSERT(BlankingBignumAluYResUsed_A,
-              !adder_y_res_used && !(operation_i.op == AluOpBignumSubm && gen_adder_pqc.adder_x_res[WLEN+1])
+              !adder_y_res_used
+              && !(operation_i.op == AluOpBignumSubm && gen_adder_pqc.adder_x_res[WLEN+1])
               |-> {x_res_operand_a_mux_out, gen_adder_pqc.adder_y_op_b} == '0,
               clk_i, !rst_ni || alu_predec_error_o || !operation_commit_i)
     end else begin : gen_blanking_alu_y_res
       `ASSERT(BlankingBignumAluYResUsed_A,
-              !adder_y_res_used && !(operation_i.op == AluOpBignumSubm && gen_adder.adder_x_res[WLEN+1])
+              !adder_y_res_used
+              && !(operation_i.op == AluOpBignumSubm && gen_adder.adder_x_res[WLEN+1])
               |-> {x_res_operand_a_mux_out, gen_adder.adder_y_op_b} == '0,
               clk_i, !rst_ni || alu_predec_error_o || !operation_commit_i)
     end
@@ -2574,12 +2623,14 @@ module otbn_alu_bignum
     if (OtbnPQCEn) begin : gen_kmac_ispr_blanking
       // KMAC CFG ISPR Blanking
       `ASSERT(BlankingIsprKmacCfg_A,
-              !(|gen_pqc_wsr.kmac_cfg_wr_en) |-> gen_pqc_wsr.ispr_kmac_cfg_bignum_wdata_intg_blanked == '0,
+              !(|gen_pqc_wsr.kmac_cfg_wr_en) |->
+              gen_pqc_wsr.ispr_kmac_cfg_bignum_wdata_intg_blanked == '0,
               clk_i, !rst_ni || ispr_predec_error_o || alu_predec_error_o || !operation_commit_i)
 
       // KMAC MSG ISPR Blanking
       `ASSERT(BlankingIsprKmacMsgA,
-              !((|gen_pqc_wsr.kmac_msg_wr_en) | ispr_predec_bignum_i.ispr_wr_en[IsprKmacMsg]) |-> gen_pqc_wsr.ispr_kmac_msg_bignum_wdata_intg_blanked == '0,
+              !((|gen_pqc_wsr.kmac_msg_wr_en) | ispr_predec_bignum_i.ispr_wr_en[IsprKmacMsg]) |->
+              gen_pqc_wsr.ispr_kmac_msg_bignum_wdata_intg_blanked == '0,
               clk_i, !rst_ni || ispr_predec_error_o || alu_predec_error_o || !operation_commit_i)
     end
   endgenerate

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -189,6 +189,15 @@ module otbn_controller
 );
   import prim_mubi_pkg::*;
 
+  generate
+    if (!OtbnPQCEn) begin : gen_unused_ports
+      // Tie off unused inputs
+      logic unused_bits;
+      assign unused_bits = ^{kmac_msg_write_ready_i, kmac_msg_pending_write_i,
+                             kmac_digest_valid_i};
+    end
+  endgenerate
+
   otbn_state_e state_q, state_d;
 
 

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -404,10 +404,12 @@ module otbn_controller
   // allowed if it can accept new data.
   generate
     if (OtbnPQCEn) begin : gen_ispr_stall_pqc
-      assign ispr_stall = (rnd_req_raw & ~rnd_valid_i) | (gen_kmac_nets.kmac_digest_req_raw & ~kmac_digest_valid_i);
+      assign ispr_stall = (rnd_req_raw & ~rnd_valid_i) |
+                          (gen_kmac_nets.kmac_digest_req_raw & ~kmac_digest_valid_i);
 
-      assign gen_kmac_nets.kmac_write_stall = (gen_kmac_nets.kmac_msg_write_req_raw & ~kmac_msg_write_ready_i)
-                                | (gen_kmac_nets.kmac_msg_partial_raw & kmac_msg_pending_write_i);
+      assign gen_kmac_nets.kmac_write_stall =
+              (gen_kmac_nets.kmac_msg_write_req_raw & ~kmac_msg_write_ready_i) |
+              (gen_kmac_nets.kmac_msg_partial_raw & kmac_msg_pending_write_i);
 
       assign stall = mem_stall | ispr_stall | rf_indirect_stall | gen_kmac_nets.kmac_write_stall;
     end else begin : gen_ispr_stall
@@ -437,7 +439,7 @@ module otbn_controller
   assign start_secure_wipe = executing & (done_complete | err);
 
   assign jump_or_branch = (insn_valid_i &
-                           (insn_dec_shared_i.branch_insn | insn_dec_shared_i.jump_insn));
+                          (insn_dec_shared_i.branch_insn | insn_dec_shared_i.jump_insn));
 
   // Branch taken when there is a valid branch instruction and comparison passes or a valid jump
   // instruction (which is always taken)
@@ -1124,9 +1126,11 @@ module otbn_controller
         // By default write nothing
         rf_bignum_wr_en_unbuf = 2'b00;
 
-        // Only write if valid instruction wants a bignum rf write and it isn't stalled. If instruction
-        // doesn't execute (e.g. due to an error) the write won't commit.
-        if (insn_valid_i && insn_dec_bignum_i.rf_we && !rf_indirect_stall && !gen_kmac_nets.kmac_write_stall) begin
+        // Only write if valid instruction wants a bignum rf write and it isn't stalled.
+        // If instruction doesn't execute (e.g. due to an error) the write won't commit.
+        if (insn_valid_i && insn_dec_bignum_i.rf_we && !rf_indirect_stall &&
+           !gen_kmac_nets.kmac_write_stall)
+        begin
           if (insn_dec_bignum_i.mac_en && insn_dec_bignum_i.mac_shift_out) begin
             // Special handling for BN.MULQACC.SO, only enable upper or lower half depending on
             // mac_wr_hw_sel_upper.
@@ -1142,8 +1146,8 @@ module otbn_controller
         // By default write nothing
         rf_bignum_wr_en_unbuf = 2'b00;
 
-        // Only write if valid instruction wants a bignum rf write and it isn't stalled. If instruction
-        // doesn't execute (e.g. due to an error) the write won't commit.
+        // Only write if valid instruction wants a bignum rf write and it isn't stalled.
+        // If instruction doesn't execute (e.g. due to an error) the write won't commit.
         if (insn_valid_i && insn_dec_bignum_i.rf_we && !rf_indirect_stall) begin
           if (insn_dec_bignum_i.mac_en && insn_dec_bignum_i.mac_shift_out) begin
             // Special handling for BN.MULQACC.SO, only enable upper or lower half depending on
@@ -1160,8 +1164,8 @@ module otbn_controller
 
   // Bignum RF control signals from the controller aren't actually used, instead the predecoded
   // one-hot versions are. The predecoded versions get checked against the signals produced here.
-  // Buffer them to ensure they don't get optimised away (with a functionally correct OTBN they will
-  // always be identical).
+  // Buffer them to ensure they don't get optimised away (with a functionally correct OTBN they
+  // will always be identical).
   prim_buf #(
     .Width(2)
   ) u_bignum_wr_en_buf (
@@ -1695,9 +1699,12 @@ module otbn_controller
 
   generate
     if (OtbnPQCEn) begin : gen_kmac_raw
-      assign gen_kmac_nets.kmac_digest_req_raw = insn_valid_i & ispr_rd_insn & (ispr_addr_o == IsprKmacDigest);
-      assign gen_kmac_nets.kmac_msg_write_req_raw = insn_valid_i & ispr_wr_insn & (ispr_addr_o == IsprKmacMsg);
-      assign gen_kmac_nets.kmac_msg_partial_raw = insn_valid_i & ispr_wr_insn & (ispr_addr_o == IsprKmacPartialW);
+      assign gen_kmac_nets.kmac_digest_req_raw    = insn_valid_i & ispr_rd_insn &
+                                                    (ispr_addr_o == IsprKmacDigest);
+      assign gen_kmac_nets.kmac_msg_write_req_raw = insn_valid_i & ispr_wr_insn &
+                                                    (ispr_addr_o == IsprKmacMsg);
+      assign gen_kmac_nets.kmac_msg_partial_raw   = insn_valid_i & ispr_wr_insn &
+                                                    (ispr_addr_o == IsprKmacPartialW);
     end
   endgenerate
 

--- a/hw/ip/otbn/rtl/otbn_mac_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_mac_bignum.sv
@@ -54,6 +54,14 @@ module otbn_mac_bignum
   // Tie unused ports to '0
   generate
     if (!OtbnPQCEn) begin : gen_unused_outputs
+      // Tie off unused inputs
+      logic unused_bits;
+      assign unused_bits = ^{operation_i.sel, operation_i.lane_mode, operation_i.lane_word_32,
+                             operation_i.lane_word_16, operation_i.exec_mode,
+                             operation_i.data_type,sec_wipe_acch_urnd_i,
+                             ispr_acch_wr_data_intg_i, ispr_acch_wr_en_i};
+
+      // Drive outputs to 0
       assign ispr_acch_intg_o = '0;
     end
   endgenerate

--- a/hw/ip/otbn/rtl/otbn_mac_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_mac_bignum.sv
@@ -102,7 +102,8 @@ module otbn_mac_bignum
   generate
     if (OtbnPQCEn) begin : gen_mul_pqc
       unified_mul mul (
-        .word_mode         ({operation_i.mulv, operation_i.data_type}), // 00 = 64x64, 11 = 4x32x32, 10 = 16x16x16
+        // 00 = 64x64, 11 = 4x32x32, 10 = 16x16x16
+        .word_mode         ({operation_i.mulv, operation_i.data_type}),
         .word_sel_A        (operation_i.operand_a_qw_sel),
         .word_sel_B        (operation_i.operand_b_qw_sel),
         .exec_mode         (operation_i.exec_mode),
@@ -366,7 +367,8 @@ module otbn_mac_bignum
 
       // Only write to accumulator if the MAC is enabled or an ACC ISPR write is occurring or secure
       // wipe of the internal state is occurring.
-      assign acch_en = (mac_en_i & mac_commit_i & operation_i.mulv) | ispr_acch_wr_en_i | sec_wipe_acch_urnd_i;
+      assign acch_en = (mac_en_i & mac_commit_i & operation_i.mulv) |
+                       ispr_acch_wr_en_i | sec_wipe_acch_urnd_i;
 
       always_ff @(posedge clk_i) begin
         if (acch_en) begin
@@ -426,6 +428,9 @@ module otbn_mac_bignum
                                               adder_result[128+64+:32], operand_a_blanked[ 64+:32],
                                               adder_result[  0+64+:32], operand_a_blanked[  0+:32]};
                       end
+                      default: begin
+                        // Not possible to reach this state
+                      end
                     endcase
                   end
                   1'b0 : begin
@@ -458,6 +463,9 @@ module otbn_mac_bignum
                                               adder_result[288+64+:32], operand_a_blanked[128+:32],
                                               adder_result[160+64+:32], operand_a_blanked[ 64+:32],
                                               adder_result[ 32+64+:32], operand_a_blanked[  0+:32]};
+                      end
+                      default: begin
+                        // Not possible to reach state
                       end
                     endcase
                   end

--- a/hw/ip/prim/rtl/prim_packer.sv
+++ b/hw/ip/prim/rtl/prim_packer.sv
@@ -199,8 +199,10 @@ module prim_packer #(
       end
       2'b 11: begin
         // both : shift the concat_data
+        /* verilator lint_off WIDTH */
         stored_data_next = concat_data[ConcatW-1:OutW];
         stored_mask_next = concat_mask[ConcatW-1:OutW];
+        /* verilator lint_on WIDTH */
       end
       default: begin
         stored_data_next = stored_data;


### PR DESCRIPTION
This does fixing for line sizes, width mismatches, and unused nets for the RTL and DV according to upstream CI for KMAC and OTBN files.